### PR TITLE
Remove thiserror dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ required-features = ["cli"]
 
 [dependencies]
 derivative = "2.2.0"
-thiserror = "1.0.37"
 
 # these are needed for the yaml reading / writing
 fraction = { version = "0.12.1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -40,7 +40,7 @@ fn parse_ifd_file(path: &str, name: &str) -> String {
         pub mod {name} {{
             #[allow(unused_imports)]
             use super::{{IfdFieldDescriptor, IfdValueType, IfdCount, IfdTypeInterpretation, IfdType}};
-            pub(crate) const ALL: [IfdFieldDescriptor; {len}] = [{arr_contents}];
+            pub(crate) static ALL: [IfdFieldDescriptor; {len}] = [{arr_contents}];
             {definitions}
         }}
     ")
@@ -87,10 +87,15 @@ fn parse_ifd_field_descriptor(mut json: JsonValue) -> (String, String) {
     (name, definition)
 }
 fn doc_lines(lines: String) -> String {
-    lines.lines().fold(String::new(), |mut out, s| {
+    let out = lines.lines().fold(String::new(), |mut out, s| {
         let _ = write!(out, "/// {s}");
         out
-    })
+    });
+    if !out.is_empty() {
+        out
+    } else {
+        "/// ".into()
+    }
 }
 fn parse_dtype(mut json: JsonValue) -> String {
     let entrys: String = json

--- a/src/dng_reader.rs
+++ b/src/dng_reader.rs
@@ -34,7 +34,15 @@ impl Display for DngReaderError {
     }
 }
 
-impl Error for DngReaderError {}
+impl Error for DngReaderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            DngReaderError::IoError(e) => Some(e),
+            DngReaderError::FormatError(e) => None,
+            DngReaderError::Other(e) => None,
+        }
+    }
+}
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/src/dng_reader.rs
+++ b/src/dng_reader.rs
@@ -38,8 +38,8 @@ impl Error for DngReaderError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             DngReaderError::IoError(e) => Some(e),
-            DngReaderError::FormatError(e) => None,
-            DngReaderError::Other(e) => None,
+            DngReaderError::FormatError(_) => None,
+            DngReaderError::Other(_) => None,
         }
     }
 }

--- a/src/dng_reader.rs
+++ b/src/dng_reader.rs
@@ -5,23 +5,25 @@ use crate::tags::{ifd, IfdType, IfdTypeInterpretation};
 use crate::FileType;
 use derivative::Derivative;
 use std::cell::RefCell;
+use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::io::{Read, Seek, SeekFrom};
-use thiserror::Error;
 
 /// The error-type produced by [DngReader]
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum DngReaderError {
     IoError(io::Error),
     FormatError(String),
     Other(String),
 }
+
 impl From<io::Error> for DngReaderError {
     fn from(e: io::Error) -> Self {
         Self::IoError(e)
     }
 }
+
 impl Display for DngReaderError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -31,6 +33,8 @@ impl Display for DngReaderError {
         }
     }
 }
+
+impl Error for DngReaderError {}
 
 #[derive(Derivative)]
 #[derivative(Debug)]

--- a/src/dng_writer.rs
+++ b/src/dng_writer.rs
@@ -9,13 +9,15 @@ use std::io::{Seek, SeekFrom, Write};
 use std::ops::DerefMut;
 use std::sync::Arc;
 
+type PlanFn<W, T> = dyn FnOnce(&mut ByteOrderWriter<W>, &T) -> io::Result<()>;
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 struct WritePlanEntry<W: Write + Seek, T> {
     offset: u32,
     size: u32,
     #[derivative(Debug = "ignore")]
-    write_fn: Box<dyn FnOnce(&mut ByteOrderWriter<W>, &T) -> io::Result<()>>,
+    write_fn: Box<PlanFn<W, T>>,
 }
 
 #[derive(Debug, Derivative)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod tags;
 #[allow(unstable_name_collisions)]
 pub mod yaml;
 
-pub use dng_reader::DngReader;
+pub use dng_reader::{DngReader, DngReaderError};
 pub use dng_writer::DngWriter;
 
 /// An enumeration over DNG / DCP files

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -53,7 +53,15 @@ impl Display for IfdYamlParserError {
     }
 }
 
-impl Error for IfdYamlParserError {}
+impl Error for IfdYamlParserError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            IfdYamlParserError::PError(pe) => Some(pe),
+            IfdYamlParserError::IoError(ioe) => Some(ioe),
+            IfdYamlParserError::Other(_, _) => None,
+        }
+    }
+}
 
 macro_rules! err {
     ($pos:expr, $($format_args:tt)*) => {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3,6 +3,7 @@ use crate::ifd::{Ifd, IfdValue};
 use crate::tags::{IfdType, IfdTypeInterpretation, IfdValueType, MaybeKnownIfdFieldDescriptor};
 use fraction::Ratio;
 use lazy_regex::regex_captures;
+use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::fs::File;
 use std::io;
@@ -10,29 +11,31 @@ use std::io::Read;
 use std::iter::once;
 use std::path::PathBuf;
 use std::sync::Arc;
-use thiserror::Error;
 use yaml_peg::parser::parse;
 use yaml_peg::parser::PError;
 use yaml_peg::repr::RcRepr;
 use yaml_peg::Node;
 
 /// The error-type produced by the [IfdYamlParser]
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum IfdYamlParserError {
     PError(PError),
     IoError(io::Error),
     Other(u64, String),
 }
+
 impl From<PError> for IfdYamlParserError {
     fn from(e: PError) -> Self {
         Self::PError(e)
     }
 }
+
 impl From<io::Error> for IfdYamlParserError {
     fn from(e: io::Error) -> Self {
         Self::IoError(e)
     }
 }
+
 impl Display for IfdYamlParserError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -49,6 +52,8 @@ impl Display for IfdYamlParserError {
         }
     }
 }
+
+impl Error for IfdYamlParserError {}
 
 macro_rules! err {
     ($pos:expr, $($format_args:tt)*) => {


### PR DESCRIPTION
As far as I see, `thiserror` dependency is only used for deriving the `std::error::Error` trait, which can be done trivially.
This PR removes it.