### PR TITLE
Remove thiserror dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ required-features = ["cli"]
 
 [dependencies]
 derivative = "2.2.0"
-thiserror = "1.0.37"
 
 # these are needed for the yaml reading / writing
 fraction = { version = "0.12.1", optional = true }

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 use json::JsonValue;
 use std::env;
+use std::fmt::Write as FmtWrite;
 use std::fs;
 use std::fs::File;
 use std::io::Write;
@@ -28,10 +29,10 @@ fn parse_ifd_file(path: &str, name: &str) -> String {
         .map(|entry| parse_ifd_field_descriptor(entry.take()))
         .collect();
     let definitions: String = entries.iter().map(|(_, code)| code.to_string()).collect();
-    let arr_contents: String = entries
-        .iter()
-        .map(|(name, _)| format!("{name}, "))
-        .collect();
+    let arr_contents: String = entries.iter().fold(String::new(), |mut output, (name, _)| {
+        let _ = write!(output, "{name}, ");
+        output
+    });
     let len = entries.len();
     format!("
         /// Tags contained in the {name} namespace
@@ -39,7 +40,7 @@ fn parse_ifd_file(path: &str, name: &str) -> String {
         pub mod {name} {{
             #[allow(unused_imports)]
             use super::{{IfdFieldDescriptor, IfdValueType, IfdCount, IfdTypeInterpretation, IfdType}};
-            pub(crate) const ALL: [IfdFieldDescriptor; {len}] = [{arr_contents}];
+            pub(crate) static ALL: [IfdFieldDescriptor; {len}] = [{arr_contents}];
             {definitions}
         }}
     ")
@@ -86,7 +87,15 @@ fn parse_ifd_field_descriptor(mut json: JsonValue) -> (String, String) {
     (name, definition)
 }
 fn doc_lines(lines: String) -> String {
-    lines.lines().map(|s| format!("/// {s}")).collect()
+    let out = lines.lines().fold(String::new(), |mut out, s| {
+        let _ = write!(out, "/// {s}");
+        out
+    });
+    if !out.is_empty() {
+        out
+    } else {
+        "/// ".into()
+    }
 }
 fn parse_dtype(mut json: JsonValue) -> String {
     let entrys: String = json
@@ -153,15 +162,14 @@ fn parse_ifd_type(json: JsonValue) -> String {
     }
 }
 fn parse_reverse_map(json: JsonValue) -> String {
-    let entries: String = json
-        .entries()
-        .map(|(k, v)| {
-            format!(
-                r#"({}, "{}"), "#,
-                v.as_str().unwrap().replace("bit ", ""),
-                k
-            )
-        })
-        .collect();
+    let entries: String = json.entries().fold(String::new(), |mut output, (k, v)| {
+        let _ = write!(
+            output,
+            r#"({}, "{}"), "#,
+            v.as_str().unwrap().replace("bit ", ""),
+            k
+        );
+        output
+    });
     format!("&[{entries}]")
 }

--- a/src/dng_reader.rs
+++ b/src/dng_reader.rs
@@ -5,29 +5,41 @@ use crate::tags::{ifd, IfdType, IfdTypeInterpretation};
 use crate::FileType;
 use derivative::Derivative;
 use std::cell::RefCell;
+use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::io;
 use std::io::{Read, Seek, SeekFrom};
-use thiserror::Error;
 
 /// The error-type produced by [DngReader]
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum DngReaderError {
     IoError(io::Error),
     FormatError(String),
     Other(String),
 }
+
 impl From<io::Error> for DngReaderError {
     fn from(e: io::Error) -> Self {
         Self::IoError(e)
     }
 }
+
 impl Display for DngReaderError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             DngReaderError::IoError(e) => f.write_fmt(format_args!("IoError: '{:?}'", e)),
             DngReaderError::FormatError(e) => f.write_fmt(format_args!("FormatError: '{}'", e)),
             DngReaderError::Other(e) => f.write_fmt(format_args!("Other: '{}'", e)),
+        }
+    }
+}
+
+impl Error for DngReaderError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            DngReaderError::IoError(e) => Some(e),
+            DngReaderError::FormatError(_) => None,
+            DngReaderError::Other(_) => None,
         }
     }
 }

--- a/src/dng_writer.rs
+++ b/src/dng_writer.rs
@@ -9,13 +9,15 @@ use std::io::{Seek, SeekFrom, Write};
 use std::ops::DerefMut;
 use std::sync::Arc;
 
+type PlanFn<W, T> = dyn FnOnce(&mut ByteOrderWriter<W>, &T) -> io::Result<()>;
+
 #[derive(Derivative)]
 #[derivative(Debug)]
 struct WritePlanEntry<W: Write + Seek, T> {
     offset: u32,
     size: u32,
     #[derivative(Debug = "ignore")]
-    write_fn: Box<dyn FnOnce(&mut ByteOrderWriter<W>, &T) -> io::Result<()>>,
+    write_fn: Box<PlanFn<W, T>>,
 }
 
 #[derive(Debug, Derivative)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ pub mod tags;
 #[allow(unstable_name_collisions)]
 pub mod yaml;
 
-pub use dng_reader::DngReader;
+pub use dng_reader::{DngReader, DngReaderError};
 pub use dng_writer::DngWriter;
 
 /// An enumeration over DNG / DCP files


### PR DESCRIPTION
As far as I see, `thiserror` dependency is only used for deriving the `std::error::Error` trait, which can be done trivially.
This PR removes it.

It might also be worth considering to remove the `Derivative` dependency to make this crate dependency-free and not pulling in all the procedural macro machinery. How important is it to have custom Debug implementations? Maybe they could be done manually.