### PR TITLE
Make naming adhere to Rust API guidelines, docs, CLI help, dependencies bump

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,21 @@
 [package]
 name = "dng"
-description = "A pure rust library for reading / writing DNG files providing access to the raw data"
-version = "1.5.2"
+description = "A pure Rust library for reading/writing of DNG files, providing access to the RAW data"
+version = "1.6.0"
 keywords = ["dng", "raw", "tiff", "ifd", "exif"]
-categories = ["command-line-utilities", "multimedia::images", "multimedia::encoding", "multimedia::video"]
+categories = [
+    "command-line-utilities",
+    "multimedia::images",
+    "multimedia::encoding",
+    "multimedia::video",
+]
 repository = "https://github.com/apertus-open-source-cinema/dng-rs"
 readme = "README.md"
 license = "AGPL-3.0"
 edition = "2021"
 
 [features]
+default = []
 yaml = ["dep:fraction", "dep:lazy-regex", "dep:textwrap", "dep:yaml-peg"]
 cli = ["yaml", "dep:clap"]
 
@@ -22,18 +28,17 @@ name = "compile_dng"
 required-features = ["cli"]
 
 [dependencies]
-derivative = "2.2.0"
-thiserror = "1.0.37"
+derivative = "2.2"
+thiserror = "2"
 
-# these are needed for the yaml reading / writing
-fraction = { version = "0.12.1", optional = true }
-lazy-regex = { version = "2.3.1", optional = true }
-textwrap = { version = "0.16.0", optional = true }
-yaml-peg = { version = "1.0.5", optional = true }
+# these are needed for the yaml reading/writing
+fraction = { version = "0.15", optional = true }
+lazy-regex = { version = "3.4", optional = true }
+textwrap = { version = "0.16", optional = true }
+yaml-peg = { version = "1.0", optional = true }
 
 # this is only needed for the cli tools
-clap = { version = "4.0.22", features = ["derive"], optional = true }
-
+clap = { version = "4.5", features = ["derive"], optional = true }
 
 [build-dependencies]
-json = "0.12.4"
+json = "0.12"

--- a/README.md
+++ b/README.md
@@ -1,54 +1,58 @@
-# DNG-rs &emsp; [![crates-shield]][crates.io] [![docs-shield]][docs.rs]
+# `dng` &emsp; [![crates-shield]][crates.io] [![docs-shield]][docs.rs]
 
 [crates-shield]: https://img.shields.io/crates/v/dng.svg
 [crates.io]: https://crates.io/crates/dng
-
 [docs-shield]: https://img.shields.io/docsrs/dng.svg
 [docs.rs]: https://docs.rs/dng
 
-**A pure rust library for reading / writing DNG files providing access to the raw data in a zero-copy friendly way.**
-Also containing code for reading / writing a human-readable YAML representation of DNG tags / the IFD structure.
-DNG-rs also supports interacting with DCP (Dng Camera Profile) files, but that is on a best-effort basis since I
+**A pure rust library for reading/writing DNG files providing access to the raw data in a zero-copy friendly way.**
+Also containing code for reading/writing a human-readable YAML representation of DNG tags/the IFD structure.
+
+The crate also supports interacting with DCP (DNG Camera Profile) files, but that is on a best-effort basis since I
 was unable to find official documentation on that.
 
 ## Tools
+
 This library also contains a pair of cli tools for converting a DNG into a human-readable YAML representation and back.
+
 These are kind of similar to [dcpTool](https://dcptool.sourceforge.net/Usage.html)'s `-d` and `-c` but use YAML rather than XML.
 
-```shell
-$ target/debug/dump_dng -h                                           
-Dump the IFD metadata of a TIFF / DNG image to a human readable yaml representation
+### `dump_dng`
+
+```
+Dump the IFD metadata of a TIFF/DNG image to a human readable YAML representation
 
 Usage: dump_dng [OPTIONS] <FILE>
 
 Arguments:
-  <FILE>  input file to get the metadata from
+  <FILE>  Input file to get the metadata from
 
 Options:
-  -f, --dump-rational-as-float  convert Rational and SRational types to float for better readability (this is lossy)
-  -e, --extract                 extract strips, tiles and larger blobs into a directory. also write the ifd chain as a yaml file there
-  -h, --help                    Print help information
-  -V, --version                 Print version information
-
+  -f, --dump-rational-as-float  Convert (signed) rational types to float for better readability (this is lossy!)
+  -e, --extract                 Extract strips, tiles and larger blobs into a directory; also write the IFD chain as a YAML file there
+  -h, --help                    Print help
+  -V, --version                 Print version
 ```
 
-```shell
-$ target/debug/compile_dng -h 
-Assemble a DNG file from some of other dng files, plain raw files and metadata
+### `compile_dng`
+
+```
+Assemble a DNG file from some of other DNG files, plain RAW files and metadata
 
 Usage: compile_dng [OPTIONS] --yaml <YAML>
 
 Options:
-      --yaml <YAML>  input YAML file to get the metadata from
-      --dcp          
-  -b, --big-endian   
-  -h, --help         Print help information
-  -V, --version      Print version information
+      --yaml <YAML>  Input YAML file to get the metadata from
+      --dcp          Write the DCP magic bytes (DNG Camera profile) instead of the DNG ones
+  -b, --big-endian   Write a big endian DNG (default: little endian)
+  -h, --help         Print help
+  -V, --version      Print version
 ```
 
-example:
-```shell
-$ target/debug/dump_dng src/yaml/testdata/axiom_beta_simulated.dcp -f 
+Example:
+
+```
+$ dump_dng src/yaml/testdata/axiom_beta_simulated.dcp -f
 UniqueCameraModel: "AXIOM Beta"
 ProfileName: "AXIOM Beta spectral simulated"
 ProfileEmbedPolicy: allow copying
@@ -67,5 +71,7 @@ ColorMatrix2: [
 ```
 
 ## Current Status
+
 This library should be in a usable state for many applications. However, a more high-level API is not implemented (yet?).
+
 For that (and support for other raw formats) you might want to use [rawloader](https://docs.rs/rawloader/latest/rawloader/).

--- a/build.rs
+++ b/build.rs
@@ -85,9 +85,11 @@ fn parse_ifd_field_descriptor(mut json: JsonValue) -> (String, String) {
     );
     (name, definition)
 }
+
 fn doc_lines(lines: String) -> String {
     lines.lines().map(|s| format!("/// {s}")).collect()
 }
+
 fn parse_dtype(mut json: JsonValue) -> String {
     let entrys: String = json
         .members_mut()
@@ -95,6 +97,7 @@ fn parse_dtype(mut json: JsonValue) -> String {
         .collect();
     format!("&[{entrys}]")
 }
+
 fn parse_single_dtype(json: JsonValue) -> String {
     match json.as_str().unwrap() {
         "BYTE" => "IfdValueType::Byte".to_string(),
@@ -102,16 +105,17 @@ fn parse_single_dtype(json: JsonValue) -> String {
         "SHORT" => "IfdValueType::Short".to_string(),
         "LONG" => "IfdValueType::Long".to_string(),
         "RATIONAL" => "IfdValueType::Rational".to_string(),
-        "SBYTE" => "IfdValueType::SByte".to_string(),
+        "SBYTE" => "IfdValueType::SignedByte".to_string(),
         "UNDEFINED" => "IfdValueType::Undefined".to_string(),
-        "SSHORT" => "IfdValueType::SShort".to_string(),
-        "SLONG" => "IfdValueType::SLong".to_string(),
-        "SRATIONAL" => "IfdValueType::SRational".to_string(),
+        "SSHORT" => "IfdValueType::SignedShort".to_string(),
+        "SLONG" => "IfdValueType::SignedLong".to_string(),
+        "SRATIONAL" => "IfdValueType::SignedRational".to_string(),
         "FLOAT" => "IfdValueType::Float".to_string(),
         "DOUBLE" => "IfdValueType::Double".to_string(),
         _ => unreachable!(),
     }
 }
+
 fn parse_count(json: JsonValue) -> String {
     let str = json.as_str().unwrap();
     match str.parse::<u32>() {
@@ -119,6 +123,7 @@ fn parse_count(json: JsonValue) -> String {
         Err(_) => "IfdCount::N".to_string(),
     }
 }
+
 fn parse_interpretation(mut json: JsonValue) -> String {
     let kind = json.remove("kind").take_string().unwrap();
     match kind.as_str() {
@@ -144,6 +149,7 @@ fn parse_interpretation(mut json: JsonValue) -> String {
         _ => "IfdTypeInterpretation::Default".to_string(),
     }
 }
+
 fn parse_ifd_type(json: JsonValue) -> String {
     match json.as_str().unwrap() {
         "IFD" => "IfdType::Ifd".to_string(),
@@ -152,6 +158,7 @@ fn parse_ifd_type(json: JsonValue) -> String {
         _ => unreachable!(),
     }
 }
+
 fn parse_reverse_map(json: JsonValue) -> String {
     let entries: String = json
         .entries()

--- a/src/bin/compile_dng.rs
+++ b/src/bin/compile_dng.rs
@@ -6,19 +6,18 @@ use std::fs::{File, OpenOptions};
 use std::io::Read;
 use std::path::Path;
 
-/// Assemble a DNG file from some of other dng files, plain raw files and metadata
 #[derive(clap::Parser)]
-#[command(author, version, about, long_about = None)]
+#[command(author, version, about="Assemble a DNG file from some of other DNG files, plain RAW files and metadata", long_about = None)]
 struct Args {
-    /// input YAML file to get the metadata from
+    /// Input YAML file to get the metadata from
     #[arg(long)]
     yaml: String,
 
-    // write the DCP magic bytes (DNG Camera profile) instead of the DNG ones
+    /// Write the DCP magic bytes (DNG Camera profile) instead of the DNG ones
     #[arg(long, action)]
     dcp: bool,
 
-    // write a big endian DNG (default: little endian)
+    /// Write a big endian DNG (default: little endian)
     #[arg(short = 'b', long, action)]
     big_endian: bool,
 }

--- a/src/byte_order_rw/byte_order_reader.rs
+++ b/src/byte_order_rw/byte_order_reader.rs
@@ -8,6 +8,7 @@ pub struct ByteOrderReader<R: Read> {
     reader: R,
     is_little_endian: bool,
 }
+
 impl<R: Read> ByteOrderReader<R> {
     pub fn new(reader: R, is_little_endian: bool) -> Self {
         Self {
@@ -31,6 +32,7 @@ macro_rules! generate_read_function {
         }
     };
 }
+
 impl<R: Read> ByteOrderReader<R> {
     generate_read_function!(read_u8, u8);
     generate_read_function!(read_i8, i8);
@@ -51,6 +53,7 @@ impl<R: Read> Deref for ByteOrderReader<R> {
         &self.reader
     }
 }
+
 impl<R: Read> DerefMut for ByteOrderReader<R> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.reader

--- a/src/byte_order_rw/byte_order_writer.rs
+++ b/src/byte_order_rw/byte_order_writer.rs
@@ -8,6 +8,7 @@ pub struct ByteOrderWriter<W: Write> {
     writer: W,
     is_little_endian: bool,
 }
+
 impl<W: Write> ByteOrderWriter<W> {
     pub fn new(writer: W, is_little_endian: bool) -> Self {
         Self {
@@ -30,6 +31,7 @@ macro_rules! generate_write_function {
         }
     };
 }
+
 impl<W: Write> ByteOrderWriter<W> {
     generate_write_function!(write_u8, u8);
     generate_write_function!(write_i8, i8);
@@ -50,6 +52,7 @@ impl<W: Write> Deref for ByteOrderWriter<W> {
         &self.writer
     }
 }
+
 impl<W: Write> DerefMut for ByteOrderWriter<W> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.writer

--- a/src/dng_reader.rs
+++ b/src/dng_reader.rs
@@ -34,10 +34,11 @@ impl Display for DngReaderError {
 
 #[derive(Derivative)]
 #[derivative(Debug)]
-/// The main entrypoint for reading DNG / DCP files
+/// The main entrypoint for reading DNG/DCP files.
 ///
-/// usage example:
-/// ```rust
+/// # Examples
+///
+/// ```
 /// use std::fs::File;
 /// use dng::DngReader;
 ///
@@ -113,14 +114,23 @@ impl<R: Read + Seek> DngReader<R> {
         })
     }
 
-    /// returns the first toplevel IFD of the DNG file.
-    pub fn get_ifd0(&self) -> &Ifd {
+    /// Returns the first toplevel IFD of the DNG file.
+    pub fn first_ifd(&self) -> &Ifd {
         &self.ifds[0]
     }
 
-    pub fn get_entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
+    /// Returns the first toplevel IFD of the DNG file.
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `first_ifd()` instead"
+    )]
+    pub fn get_ifd0(&self) -> &Ifd {
+        &self.first_ifd()
+    }
+
+    pub fn entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
         for ifd in &self.ifds {
-            let result = ifd.get_entry_by_path(path);
+            let result = ifd.entry_by_path(path);
             if result.is_some() {
                 return result;
             }
@@ -128,17 +138,24 @@ impl<R: Read + Seek> DngReader<R> {
         None
     }
 
-    /// This low-level function returns the length of a single OFFSETS field
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `entry_by_path()` instead"
+    )]
+    pub fn get_entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
+        self.entry_by_path(path)
+    }
+
+    /// This low-level function returns the length of a single OFFSETS field.
+    ///
     /// Lists are not supported (you must query the individual list member)
     pub fn needed_buffer_size_for_offsets(
         &self,
         entry: IfdEntryRef,
     ) -> Result<usize, DngReaderError> {
-        if let Some(IfdTypeInterpretation::Offsets { lengths }) =
-            entry.tag.get_type_interpretation()
-        {
+        if let Some(IfdTypeInterpretation::Offsets { lengths }) = entry.tag.type_interpretation() {
             let lengths_paths = entry.path.with_last_tag_replaced(lengths.as_maybe());
-            let lengths_value = self.get_entry_by_path(&lengths_paths);
+            let lengths_value = self.entry_by_path(&lengths_paths);
             if let Some(entry) = lengths_value {
                 Ok(entry.value.as_u32().unwrap() as usize)
             } else {
@@ -153,7 +170,8 @@ impl<R: Read + Seek> DngReader<R> {
             )))
         }
     }
-    /// This low-level function can read a single entry from an OFFSETS field to a buffer
+    /// This low-level function can read a single entry from an OFFSETS field to a buffer.
+    ///
     /// Lists are not supported (you must query the individual list member)
     pub fn read_offsets_to_buffer(
         &self,
@@ -181,7 +199,7 @@ impl<R: Read + Seek> DngReader<R> {
 
     /// Returns the Path to the IFD in which the main image data (not a preview) is stored.
     pub fn main_image_data_ifd_path(&self) -> IfdPath {
-        self.get_ifd0()
+        self.first_ifd()
             .find_entry(|entry| {
                 entry.tag == &ifd::NewSubfileType.as_maybe() && entry.value.as_u32() == Some(0)
             })
@@ -189,12 +207,12 @@ impl<R: Read + Seek> DngReader<R> {
             .unwrap_or_default()
     }
 
-    /// Returns the length in bytes needed for a buffer to store the image data from a given IFD
+    /// Returns the length in bytes needed for a buffer to store the image data from a given IFD.
     pub fn needed_buffer_length_for_image_data(
         &self,
         ifd_path: &IfdPath,
     ) -> Result<usize, DngReaderError> {
-        if let Some(compression) = self.get_entry_by_path(&ifd_path.chain_tag(ifd::Compression)) {
+        if let Some(compression) = self.entry_by_path(&ifd_path.chain_tag(ifd::Compression)) {
             if compression.value.as_u32() != Some(1) {
                 return Err(DngReaderError::Other(
                     "reading compressed images is not implemented".to_string(),
@@ -204,14 +222,14 @@ impl<R: Read + Seek> DngReader<R> {
 
         // we try the different options one after another
         if let (Some(_offsets), Some(lengths)) = (
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::StripOffsets)),
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::StripByteCounts)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::StripOffsets)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::StripByteCounts)),
         ) {
             let sum: u32 = lengths.value.as_list().map(|x| x.as_u32().unwrap()).sum();
             Ok(sum as usize)
         } else if let (Some(_offsets), Some(_lengths)) = (
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::TileOffsets)),
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::TileByteCounts)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::TileOffsets)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::TileByteCounts)),
         ) {
             Err(DngReaderError::Other(
                 "reading tiled images is not implemented".to_string(),
@@ -223,13 +241,14 @@ impl<R: Read + Seek> DngReader<R> {
             ))
         }
     }
-    /// Reads the image data from a given IFD into o given buffer
+
+    /// Reads the image data from a given IFD into o given buffer.
     pub fn read_image_data_to_buffer(
         &self,
         ifd_path: &IfdPath,
         buffer: &mut [u8],
     ) -> Result<(), DngReaderError> {
-        if let Some(compression) = self.get_entry_by_path(&ifd_path.chain_tag(ifd::Compression)) {
+        if let Some(compression) = self.entry_by_path(&ifd_path.chain_tag(ifd::Compression)) {
             if compression.value.as_u32() != Some(1) {
                 return Err(DngReaderError::Other(
                     "reading compressed images is not implemented".to_string(),
@@ -239,12 +258,12 @@ impl<R: Read + Seek> DngReader<R> {
 
         // we try the different options one after another
         if let (Some(offsets), Some(lengths)) = (
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::StripOffsets)),
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::StripByteCounts)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::StripOffsets)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::StripByteCounts)),
         ) {
             let mut reader = self.reader.borrow_mut();
-            let count = offsets.value.get_count();
-            if count != lengths.value.get_count() {
+            let count = offsets.value.count();
+            if count != lengths.value.count() {
                 return Err(DngReaderError::FormatError(
                     "the counts of OFFSETS and LENGTHS must be the same".to_string(),
                 ));
@@ -263,8 +282,8 @@ impl<R: Read + Seek> DngReader<R> {
             }
             Ok(())
         } else if let (Some(_offsets), Some(_lengths)) = (
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::TileOffsets)),
-            self.get_entry_by_path(&ifd_path.chain_tag(ifd::TileByteCounts)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::TileOffsets)),
+            self.entry_by_path(&ifd_path.chain_tag(ifd::TileByteCounts)),
         ) {
             Err(DngReaderError::Other(
                 "reading tiled images is not implemented".to_string(),

--- a/src/dng_writer.rs
+++ b/src/dng_writer.rs
@@ -65,10 +65,11 @@ impl<W: Write + Seek, T> WritePlan<W, T> {
     }
 }
 
-/// The main entrypoint for writing DNG / DCP files
+/// The main entrypoint for writing DNG/DCP files.
 ///
-/// example:
-/// ```rust
+/// # Examples
+///
+/// ```
 /// use std::fs::File;
 /// use std::sync::Arc;
 /// use dng::{DngWriter, FileType, tags};
@@ -90,7 +91,7 @@ pub struct DngWriter<W: Write + Seek> {
     plan: Arc<WritePlan<W, Self>>,
 }
 impl<W: Write + Seek> DngWriter<W> {
-    /// Writes a DNG / DCP file given the endianness and a list of toplevel [Ifd]s
+    /// Writes a DNG/DCP file given the endianness and a list of toplevel [`Ifd`]s.
     pub fn write_dng(
         writer: W,
         is_little_endian: bool,
@@ -144,14 +145,14 @@ impl<W: Write + Seek> DngWriter<W> {
         // * 2 byte type
         // * 4 byte count
         // * 4 byte value or pointer
-        let count = entry.value.get_count();
-        let dtype = entry.value.get_ifd_value_type();
+        let count = entry.value.count();
+        let dtype = entry.value.ifd_value_type();
 
-        writer.write_u16(entry.tag.numeric())?;
-        writer.write_u16(dtype.as_u16())?;
+        writer.write_u16(entry.tag.into())?;
+        writer.write_u16(dtype.into())?;
         writer.write_u32(count)?;
 
-        let required_bytes = count * dtype.needed_bytes();
+        let required_bytes = count * dtype.size() as u32;
         if required_bytes <= 4 {
             Self::write_value(entry.value, writer, self)?;
             for _ in 0..(4 - required_bytes) {
@@ -211,11 +212,11 @@ impl<W: Write + Seek> DngWriter<W> {
                 writer.write_u32(*num)?;
                 writer.write_u32(*denom)
             }
-            IfdValue::SByte(v) => writer.write_i8(*v),
+            IfdValue::SignedByte(v) => writer.write_i8(*v),
             IfdValue::Undefined(v) => writer.write_u8(*v),
-            IfdValue::SShort(v) => writer.write_i16(*v),
-            IfdValue::SLong(v) => writer.write_i32(*v),
-            IfdValue::SRational(num, denom) => {
+            IfdValue::SignedShort(v) => writer.write_i16(*v),
+            IfdValue::SignedLong(v) => writer.write_i32(*v),
+            IfdValue::SignedRational(num, denom) => {
                 writer.write_i32(*num)?;
                 writer.write_i32(*denom)
             }

--- a/src/ifd.rs
+++ b/src/ifd.rs
@@ -9,26 +9,29 @@ use std::ops::Deref;
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
-/// Represents an IFD-Tree that was read / can be written
+/// Represents an IFD-Tree that was read/can be written.
 pub struct Ifd {
     pub(crate) entries: Vec<IfdEntry>,
     pub(crate) ifd_type: IfdType,
 }
+
 impl Ifd {
-    /// Create a new `Ifd` of the given type.
+    /// Create a new Image File Directory (IFD) of the given type.
     pub fn new(ifd_type: IfdType) -> Self {
         Self {
             entries: Vec::new(),
             ifd_type,
         }
     }
-    /// Inserts all entries from another IFD overwriting previously existing entries of the same tags
+
+    /// Inserts all entries from another IFD overwriting previously existing entries of the same tags.
     pub fn insert_from_other(&mut self, other: Ifd) {
         for entry in other.entries {
             self.insert(entry.tag, entry.value)
         }
     }
-    /// Inserts an entry into the IFD, overwriting a previously existing entry of the same tag
+
+    /// Inserts an entry into the IFD, overwriting a previously existing entry of the same tag.
     pub fn insert(
         &mut self,
         tag: impl Into<MaybeKnownIfdFieldDescriptor>,
@@ -38,14 +41,17 @@ impl Ifd {
         self.entries.retain(|e| e.tag != tag);
         self.entries.push(IfdEntry::new(tag, value))
     }
-    /// Inserts an entry into the IFD at the given path, overwriting a previously existing entry there.
+
+    /// Inserts an entry into the IFD at the given path, overwriting a previously existing entry
+    /// there.
+    ///
     /// Returns the previous value if it existed, does nothing otherwise.
     pub fn replace_by_path(
         &mut self,
         path: &IfdPath,
         value: impl Into<IfdValue>,
     ) -> Option<IfdValue> {
-        let path_vec = path.as_vec();
+        let path_vec = path.as_ref();
         let mut current = if let Some(IfdPathElement::Tag(tag)) = path_vec.first() {
             self.entries
                 .iter_mut()
@@ -55,7 +61,7 @@ impl Ifd {
             return None;
         };
         for element in &path_vec[1..] {
-            current = current.and_then(|x| x.index_with_mut(element.clone()));
+            current = current.and_then(|x| x.get_mut(element.clone()));
         }
         if let Some(v) = current {
             let mut value = value.into();
@@ -65,10 +71,13 @@ impl Ifd {
             None
         }
     }
-    /// Returns an ifd entry by path. It will return None for the empty path because we cant produce
-    /// a ref with an appropriate lifetime for `self`
-    pub fn get_entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
-        let path_vec = path.as_vec();
+
+    /// Returns an IFD entry by path.
+    ///
+    /// It will return `None` for the empty path because we cant produce a ref with an appropriate
+    /// lifetime for `self`.
+    pub fn entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
+        let path_vec = path.as_ref();
         let mut current = if let Some(IfdPathElement::Tag(tag)) = path_vec.first() {
             self.entries
                 .iter()
@@ -78,7 +87,7 @@ impl Ifd {
             return None;
         };
         for element in &path_vec[1..] {
-            current = current.and_then(|x| x.index_with(element.clone()))
+            current = current.and_then(|x| x.get(element.clone()))
         }
         if let (Some(value), Some(tag)) = (&current, path.last_tag()) {
             Some(IfdEntryRef { value, path, tag })
@@ -87,10 +96,19 @@ impl Ifd {
         }
     }
 
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use entry_by_path() instead"
+    )]
+    pub fn get_entry_by_path<'a>(&'a self, path: &'a IfdPath) -> Option<IfdEntryRef<'a>> {
+        self.entry_by_path(path)
+    }
+
     /// Return the first entry satisfying the given predicate.
     pub fn find_entry(&self, predicate: impl Fn(IfdEntryRef) -> bool + Clone) -> Option<IfdPath> {
         self.find_entry_with_start_path(Default::default(), predicate)
     }
+
     fn find_entry_with_start_path(
         &self,
         path: IfdPath,
@@ -98,7 +116,7 @@ impl Ifd {
     ) -> Option<IfdPath> {
         for entry in self.entries.iter() {
             let path = path.chain_tag(entry.tag);
-            let entry_ref = entry.get_ref(&path);
+            let entry_ref = entry.build_ref(&path);
             if predicate(entry_ref) {
                 return Some(path.clone());
             }
@@ -125,10 +143,11 @@ impl Ifd {
         None
     }
 
-    /// Find all entries satisfying the given predicate
+    /// Find all entries satisfying the given predicate.
     pub fn find_entries(&self, predicate: impl Fn(IfdEntryRef) -> bool + Clone) -> Vec<IfdPath> {
         self.find_entries_with_start_path(Default::default(), predicate)
     }
+
     fn find_entries_with_start_path(
         &self,
         path: IfdPath,
@@ -137,7 +156,7 @@ impl Ifd {
         let mut entries = Vec::new();
         for entry in self.entries.iter() {
             let path = path.chain_tag(entry.tag);
-            let entry_ref = entry.get_ref(&path);
+            let entry_ref = entry.build_ref(&path);
             if predicate(entry_ref) {
                 entries.push(path.clone());
             }
@@ -161,8 +180,16 @@ impl Ifd {
         entries
     }
 
-    pub fn get_type(&self) -> IfdType {
+    pub fn ifd_type(&self) -> IfdType {
         self.ifd_type
+    }
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `ifd_type()` instead"
+    )]
+    pub fn get_type(&self) -> IfdType {
+        self.ifd_type()
     }
 
     pub fn entries(&self) -> &[IfdEntry] {
@@ -171,11 +198,12 @@ impl Ifd {
 }
 
 #[derive(Clone, Debug)]
-/// A singular entry in an IFD (that does not know its path)
+/// A singular entry in an IFD (that does not know its path).
 pub struct IfdEntry {
     pub value: IfdValue,
     pub tag: MaybeKnownIfdFieldDescriptor,
 }
+
 impl IfdEntry {
     pub fn new(
         tag: impl Into<MaybeKnownIfdFieldDescriptor>,
@@ -186,33 +214,47 @@ impl IfdEntry {
             value: value.into(),
         }
     }
-    pub fn get_ref<'a>(&'a self, path: &'a IfdPath) -> IfdEntryRef<'a> {
+
+    pub fn build_ref<'a>(&'a self, path: &'a IfdPath) -> IfdEntryRef<'a> {
         IfdEntryRef {
             value: &self.value,
             path,
             tag: &self.tag,
         }
     }
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `build_ref()` instead"
+    )]
+    pub fn get_ref<'a>(&'a self, path: &'a IfdPath) -> IfdEntryRef<'a> {
+        self.build_ref(path)
+    }
 }
 
 #[derive(Clone, PartialEq, Default, Eq)]
-/// The absolute path at which the entry is found in the IFD-tree
+/// The absolute path at which the entry is found in the IFD-tree.
 pub struct IfdPath(Vec<IfdPathElement>);
+
 impl IfdPath {
     pub fn chain_path_element(&self, element: IfdPathElement) -> Self {
         Self(self.0.iter().cloned().chain(once(element)).collect())
     }
+
     pub fn chain_list_index(&self, n: u16) -> Self {
         self.chain_path_element(IfdPathElement::ListIndex(n))
     }
+
     pub fn chain_tag(&self, tag: impl Into<MaybeKnownIfdFieldDescriptor>) -> Self {
         self.chain_path_element(IfdPathElement::Tag(tag.into()))
     }
+
     pub fn parent(&self) -> Self {
         let mut new = self.0.clone();
         new.pop();
         Self(new)
     }
+
     pub fn string_with_separator(&self, separator: &str) -> String {
         self.0
             .iter()
@@ -220,21 +262,26 @@ impl IfdPath {
             .collect::<Vec<String>>()
             .join(separator)
     }
+
+    #[deprecated(since = "1.6.0", note = "Use `as_ref()` instead")]
     pub fn as_vec(&self) -> &Vec<IfdPathElement> {
         &self.0
     }
+
     pub fn with_last_tag_replaced(&self, replacement: MaybeKnownIfdFieldDescriptor) -> Self {
-        let mut new_vec = self.as_vec().clone();
+        let mut new_vec = self.as_ref().clone();
         for elem in new_vec.iter_mut().rev() {
             if matches!(elem, IfdPathElement::Tag(_)) {
                 *elem = IfdPathElement::Tag(replacement);
                 break;
             }
         }
+
         Self(new_vec)
     }
+
     pub fn last_tag(&self) -> Option<&MaybeKnownIfdFieldDescriptor> {
-        for elem in self.as_vec().iter().rev() {
+        for elem in self.as_ref().iter().rev() {
             if let IfdPathElement::Tag(tag) = elem {
                 return Some(tag);
             }
@@ -242,6 +289,13 @@ impl IfdPath {
         None
     }
 }
+
+impl AsRef<Vec<IfdPathElement>> for IfdPath {
+    fn as_ref(&self) -> &Vec<IfdPathElement> {
+        &self.0
+    }
+}
+
 impl Debug for IfdPath {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.write_str(&self.string_with_separator("."))
@@ -249,11 +303,12 @@ impl Debug for IfdPath {
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
-/// A segment of an [IfdPath]
+/// A segment of an [`IfdPath`].
 pub enum IfdPathElement {
     Tag(MaybeKnownIfdFieldDescriptor),
     ListIndex(u16),
 }
+
 impl Display for IfdPathElement {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -264,7 +319,7 @@ impl Display for IfdPathElement {
 }
 
 #[derive(Clone, Copy, Debug)]
-/// A ref to a singular entry in an IFD
+/// A ref to a singular entry in an IFD.
 pub struct IfdEntryRef<'a> {
     pub value: &'a IfdValue,
     pub tag: &'a MaybeKnownIfdFieldDescriptor,
@@ -273,46 +328,49 @@ pub struct IfdEntryRef<'a> {
 
 #[derive(Clone, Derivative)]
 #[derivative(Debug)]
-/// A singular Value in an IFD (that doesn't know its tag or path)
+/// A singular Value in an IFD (that doesn't know its tag or path).
 pub enum IfdValue {
     Byte(u8),
     Ascii(String),
     Short(u16),
     Long(u32),
     Rational(u32, u32),
-    SByte(i8),
+    SignedByte(i8),
     Undefined(u8),
-    SShort(i16),
-    SLong(i32),
-    SRational(i32, i32),
+    SignedShort(i16),
+    SignedLong(i32),
+    SignedRational(i32, i32),
     Float(f32),
     Double(f64),
 
     List(Vec<IfdValue>),
     Ifd(Ifd),
 
-    /// this value is not produced by the reader but rather there to insert image data into the writer.
-    /// The contents will be written somewhere in the file and the tag will be replaced by a [IfdValue::Long]
-    /// pointing to that data. You are responsible for setting the corresponding length tag yourself.
+    /// This value is not produced by the reader but rather there to insert image data into the writer.
+    /// The contents will be written somewhere in the file and the tag will be replaced by a [`IfdValue::Long`]
+    /// pointing to that data.
+    ///
+    /// You are responsible for setting the corresponding length tag yourself.
     Offsets(#[derivative(Debug = "ignore")] Arc<dyn Offsets + Send + Sync>),
 }
+
 impl IfdValue {
     pub fn as_u32(&self) -> Option<u32> {
         match self {
             IfdValue::Byte(x) => Some(*x as u32),
             IfdValue::Short(x) => Some(*x as u32),
             IfdValue::Long(x) => Some(*x),
-            IfdValue::SByte(x) => Some(*x as u32),
+            IfdValue::SignedByte(x) => Some(*x as u32),
             IfdValue::Undefined(x) => Some(*x as u32),
-            IfdValue::SShort(x) => Some(*x as u32),
-            IfdValue::SLong(x) => Some(*x as u32),
+            IfdValue::SignedShort(x) => Some(*x as u32),
+            IfdValue::SignedLong(x) => Some(*x as u32),
             _ => None,
         }
     }
 
     pub fn as_f64(&self) -> Option<f64> {
         match self {
-            IfdValue::SRational(x, y) => Some(*x as f64 / *y as f64),
+            IfdValue::SignedRational(x, y) => Some(*x as f64 / *y as f64),
             IfdValue::Rational(x, y) => Some(*x as f64 / *y as f64),
             IfdValue::Float(f) => Some(*f as f64),
             IfdValue::Double(f) => Some(*f),
@@ -320,24 +378,24 @@ impl IfdValue {
         }
     }
 
-    pub fn get_ifd_value_type(&self) -> IfdValueType {
+    pub fn ifd_value_type(&self) -> IfdValueType {
         match self {
             IfdValue::Byte(_) => IfdValueType::Byte,
             IfdValue::Ascii(_) => IfdValueType::Ascii,
             IfdValue::Short(_) => IfdValueType::Short,
             IfdValue::Long(_) => IfdValueType::Long,
             IfdValue::Rational(_, _) => IfdValueType::Rational,
-            IfdValue::SByte(_) => IfdValueType::SByte,
+            IfdValue::SignedByte(_) => IfdValueType::SignedByte,
             IfdValue::Undefined(_) => IfdValueType::Undefined,
-            IfdValue::SShort(_) => IfdValueType::SShort,
-            IfdValue::SLong(_) => IfdValueType::SLong,
-            IfdValue::SRational(_, _) => IfdValueType::SRational,
+            IfdValue::SignedShort(_) => IfdValueType::SignedShort,
+            IfdValue::SignedLong(_) => IfdValueType::SignedLong,
+            IfdValue::SignedRational(_, _) => IfdValueType::SignedRational,
             IfdValue::Float(_) => IfdValueType::Float,
             IfdValue::Double(_) => IfdValueType::Double,
             IfdValue::List(list) => {
-                let ty = list[0].get_ifd_value_type();
+                let ty = list[0].ifd_value_type();
                 for elem in list {
-                    assert_eq!(elem.get_ifd_value_type(), ty)
+                    assert_eq!(elem.ifd_value_type(), ty)
                 }
                 ty
             }
@@ -348,22 +406,38 @@ impl IfdValue {
         }
     }
 
-    pub fn get_count(&self) -> u32 {
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `ifd_value_type()` instead"
+    )]
+    pub fn get_ifd_value_type(&self) -> IfdValueType {
+        self.ifd_value_type()
+    }
+
+    pub fn count(&self) -> u32 {
         match self {
             IfdValue::List(list) => list.len() as u32,
             IfdValue::Ascii(str) => str.len() as u32 + 1,
             _ => 1,
         }
     }
-    
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `count()` instead"
+    )]
+    pub fn get_count(&self) -> u32 {
+        self.count()
+    }
+
     pub fn as_list(&self) -> impl Iterator<Item = &IfdValue> {
         match self {
             Self::List(list) => Box::new(list.iter()) as Box<dyn Iterator<Item = &IfdValue>>,
             _ => Box::new(once(self)) as Box<dyn Iterator<Item = &IfdValue>>,
         }
     }
-    
-    pub fn index_with(&self, index: IfdPathElement) -> Option<&Self> {
+
+    pub fn get(&self, index: IfdPathElement) -> Option<&Self> {
         match (&self, index) {
             (Self::Ifd(ifd), IfdPathElement::Tag(tag)) => {
                 ifd.entries.iter().find(|x| x.tag == tag).map(|x| &x.value)
@@ -372,15 +446,27 @@ impl IfdValue {
             _ => None,
         }
     }
-    
-    pub fn index_with_mut(&mut self, index: IfdPathElement) -> Option<&mut Self> {
+
+    #[deprecated(since = "1.6.0", note = "Use `get()` instead")]
+    pub fn index_with(&self, index: IfdPathElement) -> Option<&Self> {
+        self.get(index)
+    }
+
+    pub fn get_mut(&mut self, index: IfdPathElement) -> Option<&mut Self> {
         match (self, index) {
-            (Self::Ifd(ifd), IfdPathElement::Tag(tag)) => {
-                ifd.entries.iter_mut().find(|x| x.tag == tag).map(|x| &mut x.value)
-            }
+            (Self::Ifd(ifd), IfdPathElement::Tag(tag)) => ifd
+                .entries
+                .iter_mut()
+                .find(|x| x.tag == tag)
+                .map(|x| &mut x.value),
             (Self::List(list), IfdPathElement::ListIndex(index)) => list.get_mut(index as usize),
             _ => None,
         }
+    }
+
+    #[deprecated(since = "1.6.0", note = "Use `get_mut()` instead")]
+    pub fn index_with_mut(&mut self, index: IfdPathElement) -> Option<&mut Self> {
+        self.get_mut(index)
     }
 }
 
@@ -393,13 +479,14 @@ macro_rules! implement_from {
         }
     };
 }
+
 implement_from!(u8, IfdValue::Byte);
 implement_from!(String, IfdValue::Ascii);
 implement_from!(u16, IfdValue::Short);
 implement_from!(u32, IfdValue::Long);
-implement_from!(i8, IfdValue::SByte);
-implement_from!(i16, IfdValue::SShort);
-implement_from!(i32, IfdValue::SLong);
+implement_from!(i8, IfdValue::SignedByte);
+implement_from!(i16, IfdValue::SignedShort);
+implement_from!(i32, IfdValue::SignedLong);
 
 impl From<&str> for IfdValue {
     fn from(x: &str) -> Self {
@@ -412,11 +499,13 @@ impl<T: Into<IfdValue> + Clone> From<&[T]> for IfdValue {
         IfdValue::List(x.iter().cloned().map(|x| x.into()).collect())
     }
 }
+
 impl<T: Into<IfdValue> + Clone, const N: usize> From<[T; N]> for IfdValue {
     fn from(x: [T; N]) -> Self {
         IfdValue::List(x.iter().cloned().map(|x| x.into()).collect())
     }
 }
+
 impl<T: Into<IfdValue> + Clone, const N: usize> From<&[T; N]> for IfdValue {
     fn from(x: &[T; N]) -> Self {
         IfdValue::List(x.iter().cloned().map(|x| x.into()).collect())
@@ -427,6 +516,7 @@ pub trait Offsets {
     fn size(&self) -> u32;
     fn write(&self, writer: &mut dyn Write) -> io::Result<()>;
 }
+
 impl<T: Deref<Target = [u8]>> Offsets for T {
     fn size(&self) -> u32 {
         self.len() as u32

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,22 +1,22 @@
-//! A pure rust library for reading / writing DNG files providing access to the raw data in a zero-copy friendly way.
+//! A pure Rust library for reading/writing of DNG files, providing access to the RAW data in a zero-copy-friendly way.
 //!
-//! It also contains code for reading / writing a human-readable YAML representation of DNG tags / the IFD structure.
-//! The library also supports interacting with DCP (Dng Camera Profile) files, but that is on a best-effort basis since I
+//! It also contains code for reading/writing a human-readable YAML representation of DNG tags resp. the IFD structure.
+//! The library also supports interacting with DCP (DNG Camera Profile) files. The latter is on a best-effort basis as I
 //! was unable to find official documentation on that.
 //!
 //! To get started, see the basic examples of [DngReader] or [DngWriter] or the more advanced usage of the library in
-//! the cli tools in `src/bin/`.
+//! the CLI tools in `src/bin/`.
 
 mod byte_order_rw;
 mod dng_reader;
 mod dng_writer;
 mod ifd_reader;
 
-/// Datastructures for representing an IFD of a read / to write DNG / DCP
+/// Datastructures for representing an IFD of a read/to write DNG/DCP.
 pub mod ifd;
-/// Datastructures and Data describing the interpretation of IFD / EXIF tags
+/// Datastructures and Data describing the interpretation of IFD/EXIF tags.
 pub mod tags;
-/// Code for reading / writing a human readable text representation of IFDs
+/// Code for reading/writing a human readable text representation of IFDs.
 #[cfg(feature = "yaml")]
 #[allow(unstable_name_collisions)]
 pub mod yaml;
@@ -27,11 +27,12 @@ pub use dng_writer::DngWriter;
 /// An enumeration over DNG / DCP files
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FileType {
-    /// A normal DNG / TIFF file
+    /// A normal DNG/TIFF file.
     Dng,
-    /// A DNG Camera Profile file. This should not contain image data
+    /// A DNG Camera Profile file. This should not contain image data.
     Dcp,
 }
+
 impl FileType {
     pub fn from_magic(magic: u16) -> Option<Self> {
         match magic {

--- a/src/tags/README.md
+++ b/src/tags/README.md
@@ -3,56 +3,64 @@
 This directory contains EXIF tag information in a machiene-readable form.
 The data in this directory is extracted from [an internet-archive snapshot of tiki-lounge](https://web.archive.org/web/20120202141457/http://www.tiki-lounge.com/~raf/tiff/fields.html)
 and then converted using a combination of [this web tool](https://www.convertjson.com/html-table-to-json.htm),
-some hacked-together js (see below) and manual labour.
+some hacked-together JS (see below) and manual labour.
 
 ## Convert JS:
 
 ```js
-input.map(x => {
-    function mapType(typeString) {
-        const dtype_string = typeString.match(/^[A-Z\n]*/g)[0];
-        const dtype = dtype_string.split('\n').slice(0, -1)
-        const kind = typeString.match(/[A-Z]*$/g)[0]
+input.map((x) => {
+  function mapType(typeString) {
+    const dtype_string = typeString.match(/^[A-Z\n]*/g)[0];
+    const dtype = dtype_string.split("\n").slice(0, -1);
+    const kind = typeString.match(/[A-Z]*$/g)[0];
 
-const rest_str = typeString.substr(
-dtype_string.length,
-typeString.length - dtype_string.length - kind.length
-).trim();
+    const rest_str = typeString
+      .substr(
+        dtype_string.length,
+        typeString.length - dtype_string.length - kind.length,
+      )
+      .trim();
 
-let rest = {};
-if (kind == "BITFLAGS") {
-    const values = Object.fromEntries(
-    rest_str
-    .split("\n")
-    .map(x => x.split(":").map(x => x.trim()).reverse())
-    )
-    rest = {values};
+    let rest = {};
+    if (kind == "BITFLAGS") {
+      const values = Object.fromEntries(
+        rest_str.split("\n").map((x) =>
+          x
+            .split(":")
+            .map((x) => x.trim())
+            .reverse(),
+        ),
+      );
+      rest = { values };
     } else if (kind == "ENUMERATED") {
-        const values = Object.fromEntries(
-        rest_str
-        .split("\n")
-        .map(x => x.split("=").map(x => x.trim()).reverse())
-        )
-        rest = {values};
-        } else {
-            if (rest_str) {
-                rest = {
-                    rest: rest_str
-                    }
-                    }
-                    }
-
-return {
-    kind,
-    dtype,
-    ...rest,
-    }
+      const values = Object.fromEntries(
+        rest_str.split("\n").map((x) =>
+          x
+            .split("=")
+            .map((x) => x.trim())
+            .reverse(),
+        ),
+      );
+      rest = { values };
+    } else {
+      if (rest_str) {
+        rest = {
+          rest: rest_str,
+        };
+      }
     }
 
-return {
+    return {
+      kind,
+      dtype,
+      ...rest,
+    };
+  }
+
+  return {
     ...x,
     name: x.name.replace(/(<([^>]+)>)/gi, "").trim(),
     type: mapType(x.type),
-    };
-})
+  };
+});
 ```

--- a/src/tags/ifd.json
+++ b/src/tags/ifd.json
@@ -1,3666 +1,3175 @@
 [
-    {
-        "tag": "0x00FE",
-        "name": "NewSubfileType",
-        "description": "Subfile type (new-style)",
-        "long_description": "The NewSubfileType field contains a bitmask of intents of the IFD.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 36",
-        "count": "1",
-        "dtype": [
-            "LONG",
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "ReducedResolution (Reduced-resolution image data)": "bit 0",
-                "Page (Single page of a multiple page document)": "bit 1",
-                "Mask (Image mask data)": "bit 2",
-                "FP (TIFF/IT Final Page)": "bit 3",
-                "MRC (TIFF-FX Mixed Raster Content)": "bit 4"
-            }
-        }
-    },
-    {
-        "tag": "0x00FF",
-        "name": "SubfileType",
-        "description": "Subfile type (old-style)",
-        "long_description": "The SubfileType field contains an enumerated value of intents of the IFD. The SubfileType field is made obsolete by NewSubfileType.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 40",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "FullResolution (Full-resolution image data)": "1",
-                "ReducedResolution (Reduced-resolution image data)": "2",
-                "Page (Single page of a multiple page document)": "3"
-            }
-        }
-    },
-    {
-        "tag": "0x0100",
-        "name": "ImageWidth",
-        "description": "Width of the image in pixels (columns)",
-        "long_description": "The ImageWidth field is the width of the image, the number of columns in the pel-path direction.",
-        "references": "See also<a href=\"#ImageLength\">ImageLength</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 34",
-        "count": "1",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0101",
-        "name": "ImageLength",
-        "description": "Length of the image in pixels (rows)",
-        "long_description": "The ImageLength field is the length of the image, the number of scanlines in the scan direction.",
-        "references": "See also<a href=\"#ImageWidth\">ImageWidth</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 34",
-        "count": "1",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0102",
-        "name": "BitsPerSample",
-        "description": "Counts of bits per sample",
-        "long_description": "The BitsPerSample field specifies the precision or number of bits that is used to represent each component of the image in an image sample. This field sometimes contains one value, for each component having the same precision, it should have a value for each component.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
-        "count": "SPP\n1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0103",
-        "name": "Compression",
-        "description": "Compression scheme",
-        "long_description": "The Compression field represents the type of compression used to compress the image data.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 30",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "None (No compression)": "1",
-                "MH (Modified Huffman compression)": "2",
-                "Group3 (T.4 compression)": "3",
-                "Group4 (T.6 (MMR) compression)": "4",
-                "LZW (LZW (Lempel-Ziv-Welch) compression)": "5",
-                "OJPEG (JPEG (old-style) compression)": "6",
-                "JPEG (JPEG (new-style) compression)": "7",
-                "JBIG (TIFF-FX JBIG (T.82) compression)": "9",
-                "JBIG_MRC (TIFF-FX JBIG (T.82) MRC (T.43) representation compression)": "10",
-                "NeXT (NeXT 2-bit grey scale compression)": "0x7FFE",
-                "Group3_1D_wordalign (Group 3 1-D (MH) compression, word-aligned)": "0x8003",
-                "Packbits (Macintosh Packbits Run-Length Encoding (RLE) compression)": "0x8005",
-                "Thunderscan (Thunderscan 4-bit compression)": "0x8029",
-                "IT8CT_MP_RasterPadding": "0x807F",
-                "IT8LW_RLE": "0x8080",
-                "IT8MP_RLE": "0x8081",
-                "IT8BL_RLE": "0x8082",
-                "PixarFilm": "0x808C",
-                "PixarLog": "0x808D",
-                "Deflate_experimental (Deflate algorithm compression (experimental value))": "0x80B2",
-                "Deflate (Deflate algorithm compression (standard value))": "0x0008",
-                "DCS": "0x80B3",
-                "JBIG_experimental": "0x8765",
-                "SGILog": "0x8774",
-                "SGILog24": "0x8775",
-                "JPEG2000_LEAD": "0x8798",
-                "JBIG2_TIFF_FX": "0x879B"
-            }
-        }
-    },
-    {
-        "tag": "0x0106",
-        "name": "PhotometricInterpretation",
-        "description": "Photometric interpretation",
-        "long_description": "The PhotometricInterpretation field describes the colorspace the image samples represent.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 37",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "WhiteIsZero (White is zero)": "0",
-                "BlackIsZero (Black is zero)": "1",
-                "RGB (RGB (Red, Green, Blue))": "2",
-                "PaletteColor (Palette color)": "3",
-                "TransparencyMask (Transparency mask)": "4",
-                "Separated (Separation)": "5",
-                "YCbCr (YCbCr)": "6",
-                "CIELab (CIE L*a*b*)": "8",
-                "ICCLab (ICC L*a*b*)": "9",
-                "ITULab (ITU-T Facsimile L*a*b*)": "10",
-                "LogL (Log luminance)": "32844",
-                "LogLUV (Log luminance and chrominance)": "32845",
-                "CFA (Color filter array)": "32803",
-                "LinearRaw (DNG Linear Raw)": "34892"
-            }
-        }
-    },
-    {
-        "tag": "0x0107",
-        "name": "Thresholding",
-        "description": "Halftone/dithering algorithm",
-        "long_description": "The Thresholding field contains the type of the halftoning/dithering algorithm used.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 41",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "NoDither": "1",
-                "OrderedDither": "2",
-                "RandomizedProcess": "3"
-            }
-        }
-    },
-    {
-        "tag": "0x0108",
-        "name": "CellWidth",
-        "description": "Width of the halftone or dither cell",
-        "long_description": "The CellWidth fields contains the width of the halftone cell. This field should only be present if Thresholding==OrderedDither.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0109",
-        "name": "CellLength",
-        "description": "Length of the halftone or dither cell",
-        "long_description": "The CellLength field contains the length of the halftone cell. This field should only be present if Thresholding==OrderedDither.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x010A",
-        "name": "FillOrder",
-        "description": "The bit order within coded image data",
-        "long_description": "The FillOrder field describes the bit order of the compressed image data. This is almost always msb-to-lsb.  The native form of Group 3 facsimile devices is lsb-to-msb.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 32",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "MSBtoLSB (most-significant-bit to least-significant-bit)": "1",
-                "LSBtoMSB (least-significant-bit to most-significant-bit)": "2"
-            }
-        }
-    },
-    {
-        "tag": "0x010D",
-        "name": "DocumentName",
-        "description": "Document name",
-        "long_description": "The DocumentName fields contains the name of the document.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x010E",
-        "name": "ImageDescription",
-        "description": "Image description",
-        "long_description": "The ImageDescription fields contains text describing the image.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x010F",
-        "name": "Make",
-        "description": "Input device make",
-        "long_description": "The Make field defines the manufacturer of the input scanner/camera that digitized the image.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0110",
-        "name": "Model",
-        "description": "Input device model",
-        "long_description": "The Model field defines the model of the input scanner/camera that digitized the image.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0111",
-        "name": "StripOffsets",
-        "description": "Offsets to strip data",
-        "long_description": "The StripOffsets field contains a value for each strip of the image that is the offset to the beginning of the strip data. The strips per image is determined from the image length and the rows per strip.  See ImageLength, RowsPerStrip. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each strip of the image, with the offsets pointing to in order the strips for each separated component.",
-        "references": "See also<a href=\"#StripByteCounts\">StripByteCounts</a>, <a href=\"#RowsPerStrip\">RowsPerStrip</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 40",
-        "count": "SPI\nSPPxSPI",
-        "dtype": [
-            "LONG",
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "OFFSETS",
-            "lengths": "StripByteCounts"
-        }
-    },
-    {
-        "tag": "0x0112",
-        "name": "Orientation",
-        "description": "Orientation of image",
-        "long_description": "The Orientation field describes how the output image is to be interpreted by rotating or flipping the coordinate origin.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "RowTopColumnLeft": "1",
-                "RowTopColumnRight": "2",
-                "RowBottomColumnRight": "3",
-                "RowBottomColumnLeft": "4",
-                "RowLeftColumnTop": "5",
-                "RowRightColumnTop": "6",
-                "RowRightColumnBottom": "7",
-                "RowLeftColumnBottom": "8",
-                "Unknown": "9"
-            }
-        }
-    },
-    {
-        "tag": "0x0115",
-        "name": "SamplesPerPixel",
-        "description": "Count of samples per pixel",
-        "long_description": "The SamplesPerPixel field is how many image or data component samples there are for each pixel. Each pixel has the same number of samples, except in the case of subsampled YCbCr and ITU/Facsimile L*a*b* per TIFF 6.0 and TIFF-FX, in which case this value reflects the number of components. Each sample represents an channel or component given the photometric interpretation, unless extra samples are present.  See ExtraSamples. The image may have multiple components but be a palettized image, in which case SamplesPerPixel would only reflect one sample for the color map entry.  See Indexed, PhotometricInterpretation==PaletteColor.",
-        "references": "See also<a href=\"#ExtraSamples\">ExtraSamples</a>, <a href=\"#Indexed\">Indexed</a>, <a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 39",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0116",
-        "name": "RowsPerStrip",
-        "description": "Rows per strip",
-        "long_description": "The RowsPerStrip field contains the number of rows (scanlines) per strip. It is used to determine the strips per image. A value of 0xFFFFFFFF, or the maximum value of the data type, implies that the entire image is one strip.",
-        "references": "See also<a href=\"#StripOffsets\">StripOffsets</a>, <a href=\"#StripByteCounts\">StripByteCounts</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 39",
-        "count": "1",
-        "dtype": [
-            "LONG",
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0117",
-        "name": "StripByteCounts",
-        "description": "Byte counts of strip data",
-        "long_description": "The StripByteCounts field contains a value for each strip of the image that is the byte count of the strip. The strips per image is determined from the image length and the rows per strip.  See ImageLength, RowsPerStrip. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each strip of the image, with the offsets pointing to in order the strips for each separated component.",
-        "references": "See also<a href=\"#StripOffsets\">StripOffsets</a>, <a href=\"#RowsPerStrip\">RowsPerStrip</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 40",
-        "count": "SPI\nSPPxSPI",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "LENGTHS"
-        }
-    },
-    {
-        "tag": "0x0118",
-        "name": "MinSampleValue",
-        "description": "Minimum sample value",
-        "long_description": "The MinSampleValue field identifies the least sample value for each sample, from the range of values possible given the bits per sample of the sample as an unsigned integer. This is for use only for statistical purposes and not footroom of the sample.",
-        "references": "See also<a href=\"#MaxSampleValue\">MaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 36",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0119",
-        "name": "MaxSampleValue",
-        "description": "Maximum sample value",
-        "long_description": "The MaxSamplesValue field identifies the greatest sample value for each sample, from the range of values possible given the bits per sample of the sample as an unsigned integer. This is for use only for statistical purposes and not headroom of the sample.",
-        "references": "See also<a href=\"#MinSampleValue\">MinSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 36",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x011A",
-        "name": "XResolution",
-        "description": "Horizontal resolution",
-        "long_description": "The XResolution contains the pixels per resolution unit in the horizontal direction, before orientation.",
-        "references": "See also<a href=\"#YResolution\">YResolution</a>, <a href=\"#ResolutionUnit\">ResolutionUnit</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x011B",
-        "name": "YResolution",
-        "description": "Vertical resolution",
-        "long_description": "The YResolution contains the pixels per resolution unit in the vertical direction, before orientation.",
-        "references": "See also<a href=\"#XResolution\">XResolution</a>, <a href=\"#ResolutionUnit\">ResolutionUnit</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x011C",
-        "name": "PlanarConfiguration",
-        "description": "Configuration of data interleaving",
-        "long_description": "The PlanarConfiguration field describes how the data is interleaved, for example pixel interleaved, scanline interleaved, or component interleaved.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 38",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Chunky (Chunky (component interleaved) sample organization)": "1",
-                "Planar (Planar (channel interleaved) sample organization)": "2",
-                "Line (Line (line interleaved) sample organization (IT8))": "0x8000"
-            }
-        }
-    },
-    {
-        "tag": "0x011D",
-        "name": "PageName",
-        "description": "Page name",
-        "long_description": "The PageName field contains the name of a page within a multiple-page document, for example a logical page number.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x011E",
-        "name": "XPosition",
-        "description": "Horizontal positional offset",
-        "long_description": "The XPosition field defines the horizontal offset from the edge of an output page of the image data. The XPosition field is used in TIFF-FX MRC to define the offset of image elements in MRC.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55\n <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x011F",
-        "name": "YPosition",
-        "description": "Vertical positional offset",
-        "long_description": "The YPosition field defines the vertical offset from the edge of an output page of the image data. The YPosition field is used in TIFF-FX MRC to define the offset of image elements in MRC.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 56\n <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0120",
-        "name": "FreeOffsets",
-        "description": "Offsets to unused file areas",
-        "long_description": "The FreeOffsets field contains an array of offsets to unused regions within the file.",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "OFFSETS",
-            "lengths": "FreeByteCounts"
-        }
-    },
-    {
-        "tag": "0x0121",
-        "name": "FreeByteCounts",
-        "description": "Byte counts of unused file areas",
-        "long_description": "The FreeOffsets field contains an array of byte counts of unused regions within the file.",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "LENGTHS"
-        }
-    },
-    {
-        "tag": "0x0122",
-        "name": "GrayResponseUnit",
-        "description": "Grayscale response curve units",
-        "long_description": "The GrayResponseUnit field contains a value describing the multiplier of the GrayResponseCurve values.  Each GrayResponseCurve value is multiplied by the value of the GrayResponseUnit, eg 1/10, 1/100, 1/1000, etcetera.",
-        "references": "See also<a href=\"#GrayResponseCurve\">GrayResponseCurve</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 33",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Tenths": "1",
-                "Hundredths": "2",
-                "Thousandths": "3",
-                "TenThousandths": "4",
-                "HundredThousandths": "5"
-            }
-        }
-    },
-    {
-        "tag": "0x0123",
-        "name": "GrayResponseCurve",
-        "description": "Grayscale response curve",
-        "long_description": "The GrayResponseCurve contains a value for each of the values of BitsPerSample many bits that describes the optical density of a pixel having that value. The values of the GrayResponseCurve are each to be multiplied by the factor described in the GrayResponseUnits field.",
-        "references": "See also<a href=\"#GrayResponseUnit\">GrayResponseUnit</a>, <a href=\"#ColorResponseCurves\">ColorResponseCurves</a>, <a href=\"#TransferFunction\">TransferFunction</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 33",
-        "count": "2toBPS",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0124",
-        "name": "T4Options",
-        "description": "Group 3 Fax options",
-        "long_description": "The T4Options field contains options of the ITU-T T.4 (CCITT Group 3 Facsmile) coding.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 11:  CCITT Bilevel Encodings\", p. 51",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "2D": "bit 0",
-                "UncompressedMode": "bit 1",
-                "EOLByteAlign": "bit 2"
-            }
-        }
-    },
-    {
-        "tag": "0x0125",
-        "name": "T6Options",
-        "description": "Group 4 Fax options",
-        "long_description": "The T6Options field contains options of the ITU-T T.6 (CCITT Group 4 Facsmile) coding.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 11:  CCITT Bilevel Encodings\", p. 52",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "UncompressedMode": "bit 1"
-            }
-        }
-    },
-    {
-        "tag": "0x0128",
-        "name": "ResolutionUnit",
-        "description": "Resolution units",
-        "long_description": "The ResolutionUnit field contains whether the resolution unit is inch, centimeter, or unknown/unspecified.",
-        "references": "See also<a href=\"#XResolution\">XResolution</a>, <a href=\"#YResolution\">YResolution</a>. <a href=\"#TIFF6\">TIFF6</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unitless (Units not specified)": "1",
-                "Inch (Units in inches)": "2",
-                "Centimeter (Units in centimeters)": "3"
-            }
-        }
-    },
-    {
-        "tag": "0x0129",
-        "name": "PageNumber",
-        "description": "Page number",
-        "long_description": "The PageNumber field contains two values, the first being the page index for this page and the second being the number of pages or zero for unknown.  Some broken applications reverse these values.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
-        "count": "2",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x012C",
-        "name": "ColorResponseUnit",
-        "description": "Color response curve units",
-        "long_description": "The ColorResponseUnit field contains a value describing the multiplier of the ColorResponseCurves values.  Each of the ColorResponseCurves' values is multiplied by the value of the ColorResponseUnit, eg 1/10, 1/100, 1/1000, etcetera.",
-        "references": "See also<a href=\"#ColorResponseCurves\">ColorResponseCurves</a>. <a href=\"#TIFF4\">TIFF4</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Tenths": "1",
-                "Hundredths": "2",
-                "Thousandths": "3",
-                "TenThousandths": "4",
-                "HundredThousandths": "5"
-            }
-        }
-    },
-    {
-        "tag": "0x012D",
-        "name": "TransferFunction",
-        "description": "Transfer function",
-        "long_description": "The TransferFunction field contains a value for each of the possible values of the pixel for each component or all components. The TransferFunction tag coincides with the ColorResponseCurves tag, if the ColorResponseUnits field exists then TransferFunction should be treated as ColorResponseCurves.",
-        "references": "See also<a href=\"#TransferRange\">TransferRange</a>, <a href=\"#ReferenceBlackWhite\">ReferenceBlackWhite</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 84",
-        "count": "2toBPS\n3x2toBPS",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0131",
-        "name": "Software",
-        "description": "Software version",
-        "long_description": "The Software field defines the software product and version that generated the image file.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0132",
-        "name": "DateTime",
-        "description": "Date and time of image creation",
-        "long_description": "The DateTime contains an ASCII string of 20 characters, with the ending binary zero. The ASCII string encodes a date and time as \"YYYY:MM:DD HH:MM:SS\".",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "20",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DATETIME"
-        }
-    },
-    {
-        "tag": "0x013B",
-        "name": "Artist",
-        "description": "Person who created the image",
-        "long_description": "The Artist field contains the artist/author of the image. This field is sometimes used to hold copyright information. This field sometimes contains two null-terminated strings, with the second being copyright information.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x013C",
-        "name": "HostComputer",
-        "description": "Host computer",
-        "long_description": "The HostComputer field contains the name of the computer which created the image file.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x013D",
-        "name": "Predictor",
-        "description": "Differencing predictor",
-        "long_description": "The Predictor field describes the differencing predictor method used. It is used with LZW and perhaps also Deflate compression schemes.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 14: Differencing Predictor\", p. 64",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "NoPrediction (No prediction sheme)": "1",
-                "HorizontalDifferencing (Horizontal differencing prediction scheme)": "2"
-            }
-        }
-    },
-    {
-        "tag": "0x013E",
-        "name": "WhitePoint",
-        "description": "Chromaticity of white point",
-        "long_description": "The WhitePoint field contains two values that describe the CIE xy components of the chromaticity of the white point, where the primaries (channels) have their reference white values.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 83",
-        "count": "2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x013F",
-        "name": "PrimaryChromaticities",
-        "description": "Chromaticities of primaries",
-        "long_description": "The PrimaryChromaticities field contains six values that described the CIE xy components of the chromaticity of the three primaries (channels) at their reference white values, where the other primaries are at their reference black values.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 83",
-        "count": "6",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0140",
-        "name": "ColorMap",
-        "description": "Color map / palette",
-        "long_description": "The ColorMap field contains a 16-bit value for each component. The values are component interleaved, for example for an RGB images the values of the colormap are stored RRR...GGG...BBB.... The colormap may contain a map for three or four component images, when either PhotometricInterpretation==PaletteColor or Indexed==Indexed.",
-        "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>, <a href=\"#Indexed\">Indexed</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 5:  Palette-color Images\", p. 23",
-        "count": "SPPx2toBPS",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "COLORMAP"
-        }
-    },
-    {
-        "tag": "0x0141",
-        "name": "HalftoneHints",
-        "description": "Halftone hints",
-        "long_description": "The HalftoneHints field contains range extents for the halftone function of values to retain tonal value.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 17:  HalftoneHints\", p. 72",
-        "count": "2",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0142",
-        "name": "TileWidth",
-        "description": "Tile width",
-        "long_description": "The TileWidth field contains the width of the tiles of the tiled image. TileWidth must be a multiple of 16.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
-        "count": "1",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0143",
-        "name": "TileLength",
-        "description": "Tile length",
-        "long_description": "The TileLength field contains the length of the tiles in the tiled image. TileLength must be a multiple of 16.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
-        "count": "1",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0144",
-        "name": "TileOffsets",
-        "description": "Offsets to tile data",
-        "long_description": "The TileOffsets field contains a value for each tile that is the offset to the beginning of the tile data. The tiles per image is determined from the image dimensions and the tile dimensions.  See ImageWidth, ImageLength, TileWidth, TileLength. The tiles are in order from left-to-right and then top-to-bottom. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each tile of the image, with the offsets pointing to in order the tiles for each separated component.",
-        "references": "See also<a href=\"#TileByteCounts\">TileByteCounts</a>, <a href=\"#TileWidth\">TileWidth</a>, <a href=\"#TileLength\">TileLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
-        "count": "TPI\nSPPxTPI",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "OFFSETS",
-            "lengths": "TileByteCounts"
-        }
-    },
-    {
-        "tag": "0x0145",
-        "name": "TileByteCounts",
-        "description": "Byte counts of tile data",
-        "long_description": "The TileByteCounts field contains a value for each tile that is the offset to the beginning of the tile data. The tiles per image is determined from the image dimensions and the tile dimensions.  See ImageWidth, ImageLength, TileWidth, TileLength. The tiles are in order from left-to-right and then top-to-bottom. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each tile of the image, with the offsets pointing to in order the tiles for each separated component.",
-        "references": "See also<a href=\"#TileOffsets\">TileOffsets</a>, <a href=\"#TileWidth\">TileWidth</a>, <a href=\"#TileLength\">TileLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
-        "count": "TPI\nSPPxTPI",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "LENGTHS"
-        }
-    },
-    {
-        "tag": "0x0146",
-        "name": "BadFaxLines",
-        "description": "Bad received fax lines",
-        "long_description": "The BadFaxLines field contains how many of the ImageLength many rows were damaged on facsimile transmission.",
-        "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0147",
-        "name": "CleanFaxData",
-        "description": "Fax data cleanliness",
-        "long_description": "The CleanFaxData field describes the damaged or undamaged state of transmitted Group 3 facsimile data.",
-        "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Clean": "0",
-                "Regenerated": "1",
-                "Unregenerated": "2"
-            }
-        }
-    },
-    {
-        "tag": "0x0148",
-        "name": "ConsecutiveBadFaxLines",
-        "description": "Maximum consecutive bad fax lines",
-        "long_description": "The ConsecutiveBadFaxLines field contains the maximum of how many facsimile lines in a row were damaged or unreadable on transmission.",
-        "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
-        "count": "1",
-        "dtype": [
-            "LONG",
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x014A",
-        "name": "SubIFDs",
-        "description": "Offsets to child IFDs",
-        "long_description": "The SubIFDs fields contains offsets to child IFDs of the current IFD that are not otherwise linked in the IFD chain.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 2:  TIFF Structure\", p. 14\n <a href=\"#TTN1\">TTN1</a> \n <a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 1:  TIFF Trees\", p. 4",
-        "count": "N",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "IFDOFFSET",
-            "ifd_type": "IFD"
-        }
-    },
-    {
-        "tag": "0x014C",
-        "name": "InkSet",
-        "description": "Ink set",
-        "long_description": "The InkSet field for separated images describes whether the inkset is CMYK, or not.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "CMYK (CMYK inkset)": "1",
-                "NotCMYK (Not a CMYK inkset)": "2"
-            }
-        }
-    },
-    {
-        "tag": "0x014D",
-        "name": "InkNames",
-        "description": "Ink names",
-        "long_description": "The InkNames field contains a null-separated list of strings that define ink/colorant names. The number of strings must be equal to the value of the NumberOfInks field.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "MULTIPLEASCII"
-        }
-    },
-    {
-        "tag": "0x014E",
-        "name": "NumberOfInks",
-        "description": "Ink count",
-        "long_description": "The NumberOfInks fields contains the number of inks for a separated image.",
-        "references": "See also<a href=\"#InkSet\">InkSet</a>, <a href=\"#InkNames\">InkNames</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0150",
-        "name": "DotRange",
-        "description": "Ink range limits",
-        "long_description": "The DotRange value contains the value of the sample for 0% and 100% saturation, for either all samples or each sample.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 71",
-        "count": "2\n2xSPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0151",
-        "name": "TargetPrinter",
-        "description": "Target printer",
-        "long_description": "The TargetPrinter describes the output printer environment.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 71",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0152",
-        "name": "ExtraSamples",
-        "description": "Description of extra components",
-        "long_description": "The ExtraSamples field defines how many data samples there are beyond those for the photometric interpretation. There may be extra components of the image beyond those for the PhotometricInterpretation.  These components are often used to represent transparency information of the samples. For each of the N many extra components, the value of this field represents the meaning of the extra sample.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 31\n <a href=\"#TIFF6\">TIFF6</a>, p. 69\n <a href=\"#TIFF6\">TIFF6</a>, p. 77",
-        "count": "N",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unspecified (Unspecified data)": "0x0000",
-                "AssociatedAlpha (Associated alpha (transparency), premultiplied)": "0x0001",
-                "UnassociatedAlpha (Unassociated alpha (transparency))": "0x0002"
-            }
-        }
-    },
-    {
-        "tag": "0x0153",
-        "name": "SampleFormat",
-        "description": "Format of data sample",
-        "long_description": "The SampleFormat field represents for each sample the data format of the sample, whether unsigned or signed integer, floating point, or undefined.  The bits per sample are determined by the BitsPerSample field. The default is unsigned integer data, and undefined data should be left or treated as unsigned integer data.",
-        "references": "See also<a href=\"#BitsPerSample\">BitsPerSample</a>, <a href=\"#SMinSampleValue\">SMinSampleValue</a>, <a href=\"#SMaxSampleValue\">SMaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "UnsignedInteger (Unsigned integer data)": "1",
-                "SignedInteger (Signed (two's complement) integer data)": "2",
-                "FloatingPoint (IEEE floating point data)": "3",
-                "Undefined (Undefined sample format)": "4"
-            }
-        }
-    },
-    {
-        "tag": "0x0154",
-        "name": "SMinSampleValue",
-        "description": "Minimum sample value of data format",
-        "long_description": "The SMinSampleValue field identifies the least sample value for each sample, from the range of values possible given the bits per sample of the sample as its type as specified by the SampleFormat field.",
-        "references": "See also<a href=\"#SMaxSampleValue\">SMaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
-        "count": "SPP",
-        "dtype": [
-            "LONG",
-            "SHORT",
-            "BYTE",
-            "SLONG",
-            "SSHORT",
-            "SBYTE",
-            "DOUBLE",
-            "FLOAT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0155",
-        "name": "SMaxSampleValue",
-        "description": "Maximum sample value of data format",
-        "long_description": "The SMaxSampleValue field identifies the greatest sample value for each sample, from the range of values possible given the bits per sample of the sample as its type as specified by the SampleFormat field.",
-        "references": "See also<a href=\"#SMinSampleValue\">SMinSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
-        "count": "SPP",
-        "dtype": [
-            "LONG",
-            "SHORT",
-            "BYTE",
-            "SLONG",
-            "SSHORT",
-            "SBYTE",
-            "DOUBLE",
-            "FLOAT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0156",
-        "name": "TransferRange",
-        "description": "Transfer range",
-        "long_description": "The TransferRange field contains two values for each of three components that are an offset and a scaling, these values expand the TransferFunction range.",
-        "references": "See also<a href=\"#TransferFunction\">TransferFunction</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 85",
-        "count": "6",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0157",
-        "name": "ClipPath",
-        "description": "Clipping path",
-        "long_description": "The ClipPath field contains the specification of a clipping path that outlines the image data to be output. The TIFF clipping path is designed to be directly compatible with PostScript path information. The clip path contains a header, 16 bytes with \"II\" or \"MM\" and then zeros, and then path operators, commands.",
-        "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6\n <a href=\"#PLRM\">PLRM</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "PSCLIPPATH"
-        }
-    },
-    {
-        "tag": "0x0158",
-        "name": "XClipPathUnits",
-        "description": "Clipping path horizontal units",
-        "long_description": "The XClipPathUnits field contains the number of horizontal clip path coordinates, the count of coordinates for the clip path coordinate system across the image.",
-        "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0159",
-        "name": "YClipPathUnits",
-        "description": "Clipping path vertical units",
-        "long_description": "The YClipPathUnits field contains the number of vertical clip path coordinates, the count of coordinates for the clip path coordinate system down the image.",
-        "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x015A",
-        "name": "Indexed",
-        "description": "Indexed (palettized) image",
-        "long_description": "The Indexed field denotes whether the image data given the photometric interpretation (see PhotometricInterpretation) is palettized or indexed to the color map (see ColorMap).",
-        "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>, <a href=\"#ColorMap\">ColorMap</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 3:  Indexed Images\", p. 11\n <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "NotIndexed (Not indexed)": "0x0000",
-                "Indexed (Indexed)": "0x0001"
-            }
-        }
-    },
-    {
-        "tag": "0x015B",
-        "name": "JPEGTables",
-        "description": "Contents of new JPEG tables",
-        "long_description": "The JPEGTables field contains an abbreviated JPEG data table specification to install the tables into the JPEG coder for JPEG coded data.",
-        "references": "<a href=\"#TTN2\">TTN2</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "JPEGTABLES"
-        }
-    },
-    {
-        "tag": "0x015F",
-        "name": "OPIProxy",
-        "description": "OPI proxy indicator",
-        "long_description": "The OPIProxy field denotes whether this image is a proxy for a higher resolution image named in the ImageID field.",
-        "references": "See also<a href=\"#ImageID\">ImageID</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, p. 15\n <a href=\"#OPI2\">OPI2</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0181",
-        "name": "Decode",
-        "description": "TIFF-FX decode array",
-        "long_description": "The Decode field contains values that define the range of colorspace values to map the range of sample values.",
-        "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "2xSPP",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DECODEARRAY"
-        }
-    },
-    {
-        "tag": "0x0182",
-        "name": "DefaultImageColor",
-        "description": "TIFF-FX default image color",
-        "long_description": "The DefaultImageColor field contains the samples of a pixel that define the default image color in TIFF-FX MRC image data.",
-        "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0190",
-        "name": "GlobalParametersIFD",
-        "description": "TIFF-FX IFD offset for global parameters",
-        "long_description": "The GlobalParametersIFD field is to contain an offset to a child IFD that contains fields with global parameters of the TIFF-FX profile file. The GlobalParametersIFD field should be written to the first IFD of the TIFF-FX file.  The global parameters IFD should contain ProfileType, FaxProfile, CodingMethods, VersionYear, and ModeNumber fields.",
-        "references": "See also<a href=\"#ProfileType\">ProfileType</a>, <a href=\"#FaxProfile\">FaxProfile</a>, <a href=\"#CodingMethods\">CodingMethods</a>, <a href=\"#VersionYear\">VersionYear</a>, <a href=\"#ModeNumber\">ModeNumber</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "IFDOFFSET",
-            "ifd_type": "IFD"
-        }
-    },
-    {
-        "tag": "0x0191",
-        "name": "ProfileType",
-        "description": "TIFF-FX profile type",
-        "long_description": "The ProfileType field describes the profile of data in the TIFF file.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unspecified": "0",
-                "Group3Fax": "1"
-            }
-        }
-    },
-    {
-        "tag": "0x0192",
-        "name": "FaxProfile",
-        "description": "TIFF-FX fax profile",
-        "long_description": "The FaxProfile field describes the TIFF-FX profile of data in the TIFF file.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#MultiProfiles\">MultiProfiles</a>. <a href=\"#TIFFFX\">TIFFFX</a> \n <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "NotProfile": "0",
-                "ProfileS": "1",
-                "ProfileF": "2",
-                "ProfileJ": "3",
-                "ProfileC": "4",
-                "ProfileL": "5",
-                "ProfileM": "6",
-                "ProfileT": "7",
-                "MultiProfiles": "255"
-            }
-        }
-    },
-    {
-        "tag": "0x0193",
-        "name": "CodingMethods",
-        "description": "TIFF-FX coding methods",
-        "long_description": "The CodingMethods field describes the coding methods used on the data in the TIFF-FX file.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "Unspecified": "bit 0",
-                "Group3_1D": "bit 1",
-                "Group3_2D": "bit 2",
-                "Group4": "bit 3",
-                "JBIG": "bit 4",
-                "JPEG": "bit 5",
-                "JBIGColor": "bit 6"
-            }
-        }
-    },
-    {
-        "tag": "0x0194",
-        "name": "VersionYear",
-        "description": "TIFF-FX version year",
-        "long_description": "The VersionYear field contains four characters forming the ASCII representation of the TIFF-FX version.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "4",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "FOURBYTEASCII"
-        }
-    },
-    {
-        "tag": "0x0195",
-        "name": "ModeNumber",
-        "description": "TIFF-FX mode number",
-        "long_description": "The ModeNumber field describes the mode of the standard used by the TIFF-FX FaxProfile field.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#FaxProfile\">FaxProfile</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Version_1_0 (FaxProfile Mode 1.0)": "0"
-            }
-        }
-    },
-    {
-        "tag": "0x01B3",
-        "name": "T82Options",
-        "description": "TIFF-FX T.82 options",
-        "long_description": "The T82Options field contains options of the ITU-T T.82 (JBIG) coding.",
-        "references": "<a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {}
-        }
-    },
-    {
-        "tag": "0x0200",
-        "name": "JPEGProc",
-        "description": "JPEG Process",
-        "long_description": "The JPEGProc field defines the JPEG process used to compress the image data, as either baseline sequential or lossless.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 104",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "BaselineSequential (Baseline sequential JPEG process)": "1",
-                "LosslessHuffman (Lossless JPEG process with Huffman encoding)": "14"
-            }
-        }
-    },
-    {
-        "tag": "0x0201",
-        "name": "JPEGInterchangeFormat",
-        "description": "Offset to JPEG interchange format",
-        "long_description": "The JPEGInterchangeFormat field contains an offset to the beginning of a block of JPEG interchange format data.",
-        "references": "See also<a href=\"#JPEGInterchangeFormatLength\">JPEGInterchangeFormatLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "OFFSETS",
-            "lengths": "JPEGInterchangeFormatLength"
-        }
-    },
-    {
-        "tag": "0x0202",
-        "name": "JPEGInterchangeFormatLength",
-        "description": "Byte count of JPEG interchange format",
-        "long_description": "The JPEGInterchangeFormatLength describes the extent of a block of JPEG interchange format data from the offset of the data.",
-        "references": "See also<a href=\"#JPEGInterchangeFormat\">JPEGInterchangeFormat</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "LENGTHS"
-        }
-    },
-    {
-        "tag": "0x0203",
-        "name": "JPEGRestartInterval",
-        "description": "JPEG restart interval",
-        "long_description": "The JPEGRestartInterval field contains the value of the restart interval of the JPEG coded data.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0205",
-        "name": "JPEGLosslessPredictors",
-        "description": "JPEG lossless predictors",
-        "long_description": "The JPEGLosslessPredictors field contains a list of the lossless predictor selection values of the JPEG coded data.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 106",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0206",
-        "name": "JPEGPointTransforms",
-        "description": "JPEG point transforms",
-        "long_description": "The JPEGPointTransforms field contains a list of the point transforms of the JPEG coded data.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 106",
-        "count": "SPP",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0207",
-        "name": "JPEGQTables",
-        "description": "Offsets to JPEG quantization tables",
-        "long_description": "The JPEGQTables field contains a list of offsets to quantization tables of the JPEG coded data. Each table is 64 bytes in extent.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
-        "count": "SPP",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "JPEGQTABLES"
-        }
-    },
-    {
-        "tag": "0x0208",
-        "name": "JPEGDCTables",
-        "description": "Offsets to JPEG DC tables",
-        "long_description": "The JPEGDCTables field contains a list of offsets to Huffman DC tables of the JPEG coded data. The extent of each is 16 bytes plus the sum of the values in those 16 bytes.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
-        "count": "SPP",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "JPEGHTABLES"
-        }
-    },
-    {
-        "tag": "0x0209",
-        "name": "JPEGACTables",
-        "description": "Offsets to JPEG AC tables",
-        "long_description": "The JPEGACTables field contains a list of offsets to Huffman AC tables of the JPEG coded data. The extent of each is 16 bytes plus the sum of the values in those 16 bytes.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
-        "count": "SPP",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "JPEGHTABLES"
-        }
-    },
-    {
-        "tag": "0x0211",
-        "name": "YCbCrCoefficients",
-        "description": "Transformation from RGB to YCbCr",
-        "long_description": "The YCbCrCoefficients fields specifies three fractions that represent the coefficients used to generate the luminance channel, Y, of YCbCr data, from RGB data.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 90",
-        "count": "3",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0212",
-        "name": "YCbCrSubSampling",
-        "description": "Chrominance component subsampling",
-        "long_description": "The YCbCrSubSampling field contains a value for both of two chromaticity components that describes the horizontal subsampling frequency and the vertical subsampling frequency, horizontal in the first value and vertical in the second value.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 91",
-        "count": "2",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x0213",
-        "name": "YCbCrPositioning",
-        "description": "Position of chrominance to luminance samples",
-        "long_description": "The YCbCrPositioning field describes whether the chrominance channels are centered among the luminance channels or cosited upon subsampling of the chrominance channels.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 92",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Centered": "1",
-                "Cosited": "2"
-            }
-        }
-    },
-    {
-        "tag": "0x0214",
-        "name": "ReferenceBlackWhite",
-        "description": "Reference black and white",
-        "long_description": "The ReferenceBlackWhite field contains two values for each of three primaries that specify headroom and footroom values for each of three primaries (channels).",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 86",
-        "count": "6",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x022F",
-        "name": "StripRowCounts",
-        "description": "TIFF-FX rows per strips",
-        "long_description": "The StripRowCounts field contains a count for each strip of the number of rows in that strip for use with TIFF-FX MRC data, which can have a variable number of row per strip. If the StripRowCounts field is present then the RowsPerStrip field is to not be.",
-        "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "SPI",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x02BC",
-        "name": "XMLPacket",
-        "description": "XMP (XML) packet",
-        "long_description": "The XMLPacket field contains embedded XMP (XML/RDF) metadata about the information.",
-        "references": "<a href=\"#XMPEMBED\">XMPEMBED</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "BLOB"
-        }
-    },
-    {
-        "tag": "0x03E7",
-        "name": "USPTOMiscellaneous",
-        "description": "USPTO Miscellaneous (private tag)",
-        "long_description": "The USPTO Miscellaenous field is by default blank.",
-        "references": "<a href=\"#YB2\">YB2</a>, p. 7",
-        "count": "253",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x800D",
-        "name": "ImageID",
-        "description": "OPI image identifier",
-        "long_description": "The ImageID tag contains a filename or other identifier of the high resolution original of this image.",
-        "references": "See also<a href=\"#OPIProxy\">OPIProxy</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, p. 15\n <a href=\"#OPI2\">OPI2</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x80A3",
-        "name": "WangTag1",
-        "description": "Wang Imaging (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x80A4",
-        "name": "WangAnnotation",
-        "description": "Wang Imaging annotation",
-        "long_description": "The WangAnnotation field contains the content of data structures that define annotations to the image per the Wang/Eastman/Kodak/eiStream annotation specification.",
-        "references": "<a href=\"#WANGANNO\">WANGANNO</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "WANGANNOTATION"
-        }
-    },
-    {
-        "tag": "0x80A5",
-        "name": "WangTag3",
-        "description": "Wang Imaging (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x80A6",
-        "name": "WangTag4",
-        "description": "Wang Imaging (private tag)",
-        "long_description": "The WangTag field contains some information put into TIFF files by Wang Imaging software.",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x828D",
-        "name": "CFARepeatPatternDim",
-        "description": "TIFF/EP color filter array dimensions",
-        "long_description": "The CFARepeatPatternDim field contains two values representing the minimum rows and columns to define the repeating patterns of the color filter array.",
-        "references": "See also<a href=\"#CFAPattern\">CFAPattern</a>, <a href=\"#SensingMethod\">SensingMethod</a>. <a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "2",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x828E",
-        "name": "CFAPattern",
-        "description": "TIFF/EP picture color filter array pattern",
-        "long_description": "The CFAPattern field contains a description of the color filter array geometric pattern for interleaving of sampling channels.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "CFA",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "CFAPATTERN"
-        }
-    },
-    {
-        "tag": "0x828F",
-        "name": "BatteryLevel",
-        "description": "TIFF/EP battery level",
-        "long_description": "The BatteryLevel field contains a value of the battery level as a fraction or string.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\nN",
-        "dtype": [
-            "RATIONAL",
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8298",
-        "name": "Copyright",
-        "description": "Copyright notice",
-        "long_description": "The Copyright field contains copyright information of the interpreted image data. GEDI standard, gedistand99.pdf, page 39, has value being 0x0828.",
-        "references": "<a href=\"#TIFF6\">TIFF6</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x829A",
-        "name": "ExposureTime",
-        "description": "TIFF/EP picture exposure time",
-        "long_description": "The ExposureTime field contains how many seconds the frame was exposed.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x829D",
-        "name": "FNumber",
-        "description": "TIFF/EP picture F number",
-        "long_description": "The FNumber field contains the F number of the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x830E",
-        "name": "ModelPixelScaleTag",
-        "description": "GeoTIFF model pixel scale",
-        "long_description": "",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "3",
-        "dtype": [
-            "DOUBLE"
-        ],
-        "interpretation": {
-            "kind": "GEOPIXELSCALE"
-        }
-    },
-    {
-        "tag": "0x8335",
-        "name": "AdventScale",
-        "description": "Advent Imaging scale (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8336",
-        "name": "AdventRevision",
-        "description": "Advent Imaging revision (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x83BB",
-        "name": "IPTCNAA",
-        "description": "IPTC/NAA metadata record",
-        "long_description": "The IPTCNAA field contains an IPTC/NAA record.",
-        "references": "<a href=\"#RICHTIFF\">RICHTIFF</a> \n <a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE",
-            "ASCII",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "IPTCNAARECORD"
-        }
-    },
-    {
-        "tag": "0x847E",
-        "name": "INGRPacketData",
-        "description": "Intergraph INGR packet data (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "INGRPACKET"
-        }
-    },
-    {
-        "tag": "0x847F",
-        "name": "INGRFlagRegisters",
-        "description": "Intergraph INGR flag registers (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "INGRFLAGREGISTER"
-        }
-    },
-    {
-        "tag": "0x8480",
-        "name": "IntergraphMatrix",
-        "description": "Intergraph matrix (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "17\n16",
-        "dtype": [
-            "DOUBLE"
-        ],
-        "interpretation": {
-            "kind": "INGRMATRIX"
-        }
-    },
-    {
-        "tag": "0x8481",
-        "name": "INGRReserved",
-        "description": "Intergraph reserved (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8482",
-        "name": "ModelTiepointTag",
-        "description": "GeoTIFF model tiepoints",
-        "long_description": "Also called Georeferencing.",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "N",
-        "dtype": [
-            "DOUBLE"
-        ],
-        "interpretation": {
-            "kind": "GEOTIEPOINTS"
-        }
-    },
-    {
-        "tag": "0x84E0",
-        "name": "Site",
-        "description": "TIFF/IT production site",
-        "long_description": "The Site field contains the location of where the image was originated or converted to TIFF/IT.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84E1",
-        "name": "ColorSequence",
-        "description": "TIFF/IT color sequence",
-        "long_description": "The ColorSequence field is a string where each letter signifies a color to be assigned to a component.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "COLORSEQUENCE"
-        }
-    },
-    {
-        "tag": "0x84E2",
-        "name": "IT8Header",
-        "description": "TIFF/IT header",
-        "long_description": "The IT8Header field contains null-separated headers from ISO 10755, ISO 10756, and ISO 10759.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "MULTIPLEASCII"
-        }
-    },
-    {
-        "tag": "0x84E3",
-        "name": "RasterPadding",
-        "description": "TIFF/IT raster padding",
-        "long_description": "The RasterPadding field describes the padding of data to byte, word, long word, sector, or double sector. When applied to line interleaved data, the padding applies to each color instead of each line.",
-        "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "ByteRaster": "0",
-                "WordRaster": "1",
-                "LongWordRaster": "2",
-                "SectorRaster": "9",
-                "LongSectorRaster": "10"
-            }
-        }
-    },
-    {
-        "tag": "0x84E4",
-        "name": "BitsPerRunLength",
-        "description": "TIFF/IT LW bits per run length",
-        "long_description": "The BitsPerRunLength field contains how many bits are required to represent the short run of the run length encoding of the TIFF/IT LW (line work) data.",
-        "references": "See also<a href=\"#BitsPerExtendedRunLength\">BitsPerExtendedRunLength</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84E5",
-        "name": "BitsPerExtendedRunLength",
-        "description": "TIFF/IT LW bits per extended run length",
-        "long_description": "The BitsPerRunLength field contains how many bits are required to represent the long run of the run length encoding of the TIFF/IT LW (line work) data.",
-        "references": "See also<a href=\"#BitsPerRunLength\">BitsPerRunLength</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84E6",
-        "name": "ColorTable",
-        "description": "TIFF/IT LW color table",
-        "long_description": "The ColorTable field contains a color identifier and transparency information for separated line work images.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>, p. 17",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84E7",
-        "name": "ImageColorIndicator",
-        "description": "TIFF/IT BP/BL foreground color indicator",
-        "long_description": "The ImageColorIndicator field describes whether the image or foreground color is in the binary image or the monochrome continuous tone image.",
-        "references": "See also<a href=\"#BackgroundColorIndicator\">BackgroundColorIndicator</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "UnspecifiedImageColor (Image color not specified)": "0",
-                "SpecifiedImageColor (Image color specified)": "1"
-            }
-        }
-    },
-    {
-        "tag": "0x84E8",
-        "name": "BackgroundColorIndicator",
-        "description": "TIFF/IT BP/BL background color indicator",
-        "long_description": "The BackgroundColorIndicator field describes whether the image or background color is in the binary image or the monochrome continuous tone image.",
-        "references": "See also<a href=\"#ImageColorIndicator\">ImageColorIndicator</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "UnspecifiedBackgroundColor (Background color not specified)": "0",
-                "SpecifiedBackgroundColor (Background color specified)": "1"
-            }
-        }
-    },
-    {
-        "tag": "0x84E9",
-        "name": "ImageColorValue",
-        "description": "TIFF/IT BP/BL foreground color value",
-        "long_description": "The ImageColorValue describes the foreground color of a TIFF/IT BP or BL bitmap.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "CSC",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84EA",
-        "name": "BackgroundColorValue",
-        "description": "TIFF/IT BP/BL background color value",
-        "long_description": "The BackgroundColorValue describes the background color of a TIFF/IT BP or BL bitmap.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "CSC",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84EB",
-        "name": "PixelIntensityRange",
-        "description": "TIFF/IT MP pixel intensity range",
-        "long_description": "The PixelIntensityRange is similar to DotRange for a TIFF/IT MP image.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84EC",
-        "name": "TransparencyIndicator",
-        "description": "TIFF/IT HC transparency indicator",
-        "long_description": "The TransparencyIndicator field denotes whether transparency information is within TIFF/IT HC data.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84ED",
-        "name": "ColorCharacterization",
-        "description": "TIFF/IT color characterization",
-        "long_description": "The ColorCharacterization fields describes colors per ISO 12641, ISO 12642, and ANSI CGATS.15.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x84EE",
-        "name": "HCUsage",
-        "description": "TIFF/IT HC usage",
-        "long_description": "The HCUsage field defines the type of information in the TIFF/IT HC file.",
-        "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
-        "count": "1",
-        "dtype": [
-            "LONG",
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {}
-        }
-    },
-    {
-        "tag": "0x8568",
-        "name": "KodakIPTC",
-        "description": "IPTC/NAA metadata record",
-        "long_description": "The KodakIPTC field contains an IPTC/NAA record.",
-        "references": "<a href=\"#RICHTIFF\">RICHTIFF</a>",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "IPTCNAARECORD"
-        }
-    },
-    {
-        "tag": "0x85B8",
-        "name": "PixelMagicJBIGOptions",
-        "description": "Pixel Magic JBIG options (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x85D8",
-        "name": "ModelTransformationTag",
-        "description": "GeoTIFF model transformation",
-        "long_description": "",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "16",
-        "dtype": [
-            "DOUBLE"
-        ],
-        "interpretation": {
-            "kind": "GEOTRANSFORM"
-        }
-    },
-    {
-        "tag": "0x8649",
-        "name": "ImageResourceBlocks",
-        "description": "Adobe Photoshop image resource blocks",
-        "long_description": "The Photoshop field contains information embedded by the Adobe Photoshop application.",
-        "references": "<a href=\"#PSFF\">PSFF</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED",
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "PHOTOSHOP"
-        }
-    },
-    {
-        "tag": "0x8769",
-        "name": "ExifIFD",
-        "description": "Exif IFD offset",
-        "long_description": "The ExifIFD field contains an offset to a sub-IFD containing Exif (digital camera) information.",
-        "references": "<a href=\"#EXIF21\">EXIF21</a>, p. 19",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "IFDOFFSET",
-            "ifd_type": "EXIF"
-        }
-    },
-    {
-        "tag": "0x8773",
-        "name": "InterColorProfile",
-        "description": "ICC profile",
-        "long_description": "The InterColorProfile field contains an InterColor Consortium (ICC) format color space characterization/profile.",
-        "references": "<a href=\"#ICCEMBED\">ICCEMBED</a> \n <a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "ICCPROFILE"
-        }
-    },
-    {
-        "tag": "0x877F",
-        "name": "TIFF_FXExtensions",
-        "description": "TIFF-FX Extensions",
-        "long_description": "The TIFF-FXExtensions field describes extensions used.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "Resolution_ImageWidth (Extended resolutions and imagewidths extension)": "bit 0",
-                "N_Layer_ProfileM (N-Layer Profile M extension)": "bit 1",
-                "SharedData (Shared data extension)": "bit 2",
-                "BilevelJBIG2_ProfileT (Black-and-White JBIG2 coding extension)": "bit 3",
-                "JBIG2Extension_ProfileM (JBIG2 mask layer coding and foreground layer color tag extension)": "bit 4"
-            }
-        }
-    },
-    {
-        "tag": "0x8780",
-        "name": "MultiProfiles",
-        "description": "TIFF-FX multiple profiles",
-        "long_description": "The MultiProfiles field describes multiple profiles used.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#FaxProfile\">FaxProfile</a>, <a href=\"#TIFF-FXExtensions\">TIFF-FXExtensions</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {
-                "ProfileS": "bit 0",
-                "ProfileF": "bit 1",
-                "ProfileJ": "bit 2",
-                "ProfileC": "bit 3",
-                "ProfileL": "bit 4",
-                "ProfileM": "bit 5",
-                "ProfileT": "bit 6",
-                "Resolution_ImageWidth (Extended resolutions and imagewidths extension)": "bit 7",
-                "N_Layer_ProfileM (N-Layer Profile M extension)": "bit 8",
-                "SharedData (Shared data extension)": "bit 9",
-                "JBIG2Extension_ProfileM (JBIG2 mask layer coding and foreground layer color tag extension)": "bit 10"
-            }
-        }
-    },
-    {
-        "tag": "0x8781",
-        "name": "SharedData",
-        "description": "TIFF-FX shared data offset",
-        "long_description": "The SharedData field cotains an offset to the TIFF-FX Extension share data block within the file.",
-        "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8782",
-        "name": "T88Options",
-        "description": "TIFF-FX T.88 options",
-        "long_description": "The T88Options field contains options of the ITU-T T.88 (JBIG2) coding.",
-        "references": "<a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
-        "count": "1\n2",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "BITFLAGS",
-            "values": {}
-        }
-    },
-    {
-        "tag": "0x87AC",
-        "name": "ImageLayer",
-        "description": "TIFF-FX MRC image layer",
-        "long_description": "The ImageLayer field contains two values, one to describe of which of the three TIFF-FX MRC layers this image component is a part, the second is the order in that the image component is to be composited.",
-        "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
-        "count": "2",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x87AF",
-        "name": "GeoKeyDirectoryTag",
-        "description": "GeoTIFF key directory",
-        "long_description": "Also called ProjectionInfoTag, CoordSystemInfoTag.",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "N",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "GEOKEYDIR"
-        }
-    },
-    {
-        "tag": "0x87B0",
-        "name": "GeoDoubleParamsTag",
-        "description": "GeoTIFF double parameters",
-        "long_description": "",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "N",
-        "dtype": [
-            "DOUBLE"
-        ],
-        "interpretation": {
-            "kind": "GEOKEYDOUBLE"
-        }
-    },
-    {
-        "tag": "0x87B1",
-        "name": "GeoAsciiParamsTag",
-        "description": "GeoTIFF ASCII parameters",
-        "long_description": "",
-        "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "GEOKEYASCII"
-        }
-    },
-    {
-        "tag": "0x8822",
-        "name": "ExposureProgram",
-        "description": "TIFF/EP picture exposure program",
-        "long_description": "The ExposureProgram field describes the exposure setting program condition of the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Undefined": "0",
-                "Manual": "1",
-                "NormalProgram": "2",
-                "AperturePriority": "3",
-                "ShutterPriority": "4",
-                "CreativeProgram": "5",
-                "ActionProgram": "6",
-                "PortraitMode": "7",
-                "LandscapeMode": "8"
-            }
-        }
-    },
-    {
-        "tag": "0x8824",
-        "name": "SpectralSensitivity",
-        "description": "TIFF/EP picture spectral sensitivity",
-        "long_description": "The SpectralSensitivity field contains a description of the sensitivity of each channel of the image data according to ASTM standards.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8825",
-        "name": "GPSInfoIFD",
-        "description": "Exif GPS offset",
-        "long_description": "The GPSInfoIFD field contains an offset to a sub-IFD containing GPS (Global Positioning System) information.",
-        "references": "<a href=\"#EXIF21\">EXIF21</a>, p. 19\n <a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "IFDOFFSET",
-            "ifd_type": "GPSINFO"
-        }
-    },
-    {
-        "tag": "0x8827",
-        "name": "ISOSpeedRatings",
-        "description": "TIFF/EP picture ISO speed ratings",
-        "long_description": "The ISOSpeedRatings field contains the ISO speed or ISO latitude of the camera as specified by ISO 12232.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8828",
-        "name": "OECF",
-        "description": "TIFF/EP picture optoelectronic conversion function",
-        "long_description": "The OECF field contains a specification of an opto-electronic conversion function as specified by ISO 14524.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x8829",
-        "name": "Interlace",
-        "description": "TIFF/EP field number",
-        "long_description": "The Interlace field contains a value that describes the vertical and horizontal field of multiple field TIFF/EP images.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x882A",
-        "name": "TimeZoneOffset",
-        "description": "TIFF/EP time zone offset",
-        "long_description": "The TimeZoneOffset contains the time zone offset in hours from GMT for the DateTimeOriginal field and optionally the DateTime field of the TIFF/EP image.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "SSHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x882B",
-        "name": "SelfTimerMode",
-        "description": "TIFF/EP self timer mode",
-        "long_description": "The SelfTimerMode field contains the number of seconds from when the plunger was depressed that the camera fired, or zero for no delay.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x885C",
-        "name": "FaxRecvParams",
-        "description": "SGI fax receival parameters (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x885D",
-        "name": "FaxSubAddress",
-        "description": "SGI fax subaddress (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x885E",
-        "name": "FaxRecvTime",
-        "description": "SGI fax receival time (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9003",
-        "name": "DateTimeOriginal",
-        "description": "TIFF/EP origination date/time",
-        "long_description": "The DateTimeOriginal field contains 20 ASCII characters in the form \"YYYY:MM:DD HH:MM:SS\" indicating the data and time when the image data was sampled.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "20",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DATETIME"
-        }
-    },
-    {
-        "tag": "0x9102",
-        "name": "CompressedBitsPerPixel",
-        "description": "TIFF/EP compressed bits per pixel",
-        "long_description": "The CompressedBitsPerPixel field contains TIFF/EP data compression information.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9201",
-        "name": "ShutterSpeedValue",
-        "description": "TIFF/EP shutter speed",
-        "long_description": "The ShutterSpeedValue contains the shutter speed in APEX units of the TIFF/EP image.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9202",
-        "name": "ApertureValue",
-        "description": "TIFF/EP picture lens aperture",
-        "long_description": "The ApertureValue field contains the APEX unit valued lens aperture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9203",
-        "name": "BrightnessValue",
-        "description": "TIFF/EP picture brightness",
-        "long_description": "The BrightnessValue field contains the APEX unit valued brightness.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9204",
-        "name": "ExposureBiasValue",
-        "description": "TIFF/EP picture exposure bias",
-        "long_description": "The ExposureBiasValue field contains the APEX unit valued exposure bias.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9205",
-        "name": "MaxApertureValue",
-        "description": "TIFF/EP picture lens maximum aperture",
-        "long_description": "The MaxApertureValue field contains the APEX unit valued minimum F number of the lens.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9206",
-        "name": "SubjectDistance",
-        "description": "TIFF/EP picture subject distance",
-        "long_description": "The SubjectDistance field contains the distance from the camera to the picture's subject, in meters.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9207",
-        "name": "MeteringMode",
-        "description": "TIFF/EP picture metering mode",
-        "long_description": "The MeteringMode field describes the metering mode of the camera.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unidentified": "0",
-                "Average": "1",
-                "CenterWeightedAverage": "2",
-                "Spot": "3",
-                "MultiSpot": "4"
-            }
-        }
-    },
-    {
-        "tag": "0x9208",
-        "name": "LightSource",
-        "description": "TIFF/EP picture light source",
-        "long_description": "The LightSource field describes the light source conditions of the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unidentified": "0",
-                "Daylight": "1",
-                "Fluorescent": "2",
-                "Tungsten": "3",
-                "Flash": "10",
-                "StandardIlluminantA": "17",
-                "StandardIlluminantB": "18",
-                "StandardIlluminantC": "19",
-                "D55Illuminant": "20",
-                "D65Illuminant": "21",
-                "D75Illuminant": "22"
-            }
-        }
-    },
-    {
-        "tag": "0x9209",
-        "name": "Flash",
-        "description": "TIFF/EP picture flash usage",
-        "long_description": "The Flash field describes the use of strobe flash with the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "FLASHEP"
-        }
-    },
-    {
-        "tag": "0x920A",
-        "name": "FocalLength",
-        "description": "TIFF/EP picture lens focal length",
-        "long_description": "The FocalLength field contains the focal length in millimeters of the lens.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x920B",
-        "name": "FlashEnergy",
-        "description": "TIFF/EP picture flash energy",
-        "long_description": "The FlashEnergy field contains the power of the strobe flash in BCPS, beam candlepower seconds, units.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x920C",
-        "name": "SpatialFrequencyResponse",
-        "description": "TIFF/EP picture spatial frequency response",
-        "long_description": "The SpatialFrequencyResponse field contains the device spatial frequency response table and values for the picture per ISO 12233.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x920D",
-        "name": "Noise",
-        "description": "TIFF/EP noise measurement",
-        "long_description": "The Noise field contains a measurement of the noise value of the TIFF/EP image.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x920E",
-        "name": "FocalPlaneXResolution",
-        "description": "TIFF/EP picture focal plane column resolution",
-        "long_description": "The FocalPlaneXResolution field contains the focal plane column resolution in FocalPlaneResolutionUnits units.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x920F",
-        "name": "FocalPlaneYResolution",
-        "description": "TIFF/EP picture focal plane row resolution",
-        "long_description": "The FocalPlaneXResolution field contains the focal plane row resolution in FocalPlaneResolutionUnit units.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9210",
-        "name": "FocalPlaneResolutionUnit",
-        "description": "TIFF/EP picture focal plane resolution unit",
-        "long_description": "The FocalPlaneResolutionUnit field describes the focal plane resolution unit.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Inch": "1",
-                "Meter": "2",
-                "Centimeter": "3",
-                "Millimeter": "4",
-                "Micrometer": "5"
-            }
-        }
-    },
-    {
-        "tag": "0x9211",
-        "name": "ImageNumber",
-        "description": "TIFF/EP image number",
-        "long_description": "The ImageNumber fields contains an identifier assigned to an image in a TIFF/EP file.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9212",
-        "name": "SecurityClassification",
-        "description": "TIFF/EP security classification",
-        "long_description": "The SecurityClassification field contains either a single ASCII character or an ASCII string describing the security classification of the image per the NITF specification (MIL-STD-2500).",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\nN",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "CHARACTERORASCII"
-        }
-    },
-    {
-        "tag": "0x9213",
-        "name": "ImageHistory",
-        "description": "TIFF/EP image modification history",
-        "long_description": "The ImageHistory field contains a description of modifications to the TIFF/EP image.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9214",
-        "name": "SubjectLocation",
-        "description": "TIFF/EP picture subject location",
-        "long_description": "The SubjectLocation field contains two coordinate values into the image of the pixel of the subject location in the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "2\n3\n4",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9215",
-        "name": "ExposureIndex",
-        "description": "TIFF/EP picture exposure index",
-        "long_description": "The ExposureIndex field contains the camera exposure index setting.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1\n2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x9216",
-        "name": "TIFFEPStandardID",
-        "description": "TIFF/EP standard identifier",
-        "long_description": "The TIFFEPStandardID field contains four ASCII characters representing the TIFF/EP standard version of a TIFF/EP file, eg '1', '0', '0', '0'.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "4",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "FOURBYTEASCII"
-        }
-    },
-    {
-        "tag": "0x9217",
-        "name": "SensingMethod",
-        "description": "TIFF/EP picture sensing method",
-        "long_description": "The SensingMethod field describes the sensors that capture the image of the picture.",
-        "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Undefined": "0",
-                "MonochromeArea": "1",
-                "OneChipColorArea": "2",
-                "TwoChipColorArea": "3",
-                "ThreeChipColorArea": "4",
-                "ColorSequentialArea": "5",
-                "MonochromeLinearArea": "6",
-                "TriLinear": "7",
-                "ColorSequentialLinear": "8"
-            }
-        }
-    },
-    {
-        "tag": "0x923A",
-        "name": "CIP3DataFile",
-        "description": "CIP3 PPF data",
-        "long_description": "The CIP3DataFile field contains a string that is to be intepreted as the filename of a CIP3 PPF file, as a field of a TIFF/IT FP IFD.",
-        "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x923B",
-        "name": "CIP3Sheet",
-        "description": "CIP3 sheet name",
-        "long_description": "The CIP3Sheet field contains a string that references the sheet to use in a multiple sheet PPF file, as a field of a TIFF/IT FP IFD.",
-        "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x923C",
-        "name": "CIP3Side",
-        "description": "CIP3 sheet side",
-        "long_description": "The CIP3Side field describes which side of a PPF sheet is to be used, as a field of a TIFF/IT FP IFD.",
-        "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
-        "count": "1",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0x935C",
-        "name": "ImageSourceData",
-        "description": "Adobe Photoshop image source data",
-        "long_description": "The ImageSourceData field contains information embedded by the Adobe Photoshop application.",
-        "references": "<a href=\"#TIFFPS\">TIFFPS</a>",
-        "count": "N",
-        "dtype": [
-            "UNDEFINED"
-        ],
-        "interpretation": {
-            "kind": "PHOTOSHOP"
-        }
-    },
-    {
-        "tag": "0xA480",
-        "name": "GDAL_METADATA",
-        "description": "GDAL metadata (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "XML"
-        }
-    },
-    {
-        "tag": "0xA481",
-        "name": "GDAL_NODATA",
-        "description": "GDAL background/nodata (private tag)",
-        "long_description": "",
-        "references": "",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC580",
-        "name": "USPTOOriginalContentType",
-        "description": "USPTO Original Content Type (private tag)",
-        "long_description": "The USPTO OriginalContentType field describes the original content type of the image.",
-        "references": "<a href=\"#YB2\">YB2</a>, p. 7",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "TextOrDrawing (Text or black and white drawing (default))": "0",
-                "Grayscale (Grayscale drawing or photograph)": "1",
-                "Color (Color drawing or photograph)": "2"
-            }
-        }
-    },
-    {
-        "tag": "0xC612",
-        "name": "DNGVersion",
-        "description": "DNG version",
-        "long_description": "The DNGVersion contains four bytes containing the numeric value of the file's conformance version level to the DNG (Digital Negative) specification.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 15",
-        "count": "4",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "FOURBYTEDIGITS"
-        }
-    },
-    {
-        "tag": "0xC613",
-        "name": "DNGBackwardVersion",
-        "description": "DNG backwards compatible version",
-        "long_description": "The DNGBackwardsVersion field contains four bytes containing the numeric value of the file's conformance version level to a DNG (Digital Negative) specification.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 15",
-        "count": "4",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "FOURBYTEDIGITS"
-        }
-    },
-    {
-        "tag": "0xC614",
-        "name": "UniqueCameraModel",
-        "description": "DNG unique camera model",
-        "long_description": "The UniqueCameraModel field contains a null-terminated ASCII string noting the camera model.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 16",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC615",
-        "name": "LocalizedCameraModel",
-        "description": "DNG localized camera model",
-        "long_description": "The LocalizedCameraModel field contains a null-terminated ASCII string or a Unicode string noting the camera model.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 17",
-        "count": "N",
-        "dtype": [
-            "ASCII",
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC616",
-        "name": "CFAPlaneColor",
-        "description": "DNG CFA plane color",
-        "long_description": "The CFAPlaneColor fields contains a list of zero-based digits indicating the order of the color planes of the color filter array pattern for the LinearRaw photometric interpretation.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 17",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC617",
-        "name": "CFALayout",
-        "description": "DNG CFA spatial layout",
-        "long_description": "The CFALayout field denotes the spatial layout of the color filter array.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 18",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Rectangular": "1",
-                "Staggered_A": "2",
-                "Staggered_B": "3",
-                "Staggered_C": "4",
-                "Staggered_D": "5"
-            }
-        }
-    },
-    {
-        "tag": "0xC618",
-        "name": "LinearizationTable",
-        "description": "DNG linearization table",
-        "long_description": "The LinearizationTable field contains a lookup table (LUT) that maps data values of the samples of the image to non-linear values.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 18",
-        "count": "N",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC619",
-        "name": "BlackLevelRepeatDim",
-        "description": "DNG black level repeat dimensions",
-        "long_description": "The BlackLevelRepeatDim field contains two values, one each for rows and columns of the black level tag.",
-        "references": "See also<a href=\"#BlackLevel\">BlackLevel</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 19",
-        "count": "2",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61A",
-        "name": "BlackLevel",
-        "description": "DNG black level",
-        "long_description": "The BlackLevel field contains the \"zero light\" or thermal black encoding level, as a repeating pattern. The values are stored in row-column-sample scan order.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 19",
-        "count": "N",
-        "dtype": [
-            "SHORT",
-            "LONG",
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61B",
-        "name": "BlackLevelDeltaH",
-        "description": "DNG black level delta - horizontal",
-        "long_description": "The BlackLevelDeltaH field encodes the per-column difference of the \"zero light\" level.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 20",
-        "count": "N\nWidth",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61C",
-        "name": "BlackLevelDeltaV",
-        "description": "DNG black level delta - vertical",
-        "long_description": "The BlackLevelDeltaV field encodes the per-row difference of the \"zero light\" level.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 20",
-        "count": "Length",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61D",
-        "name": "WhiteLevel",
-        "description": "DNG white level",
-        "long_description": "The WhiteLevel field contains the fully-saturated encoding level for the raw samples, per sample.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 21",
-        "count": "SPP",
-        "dtype": [
-            "SHORT",
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61E",
-        "name": "DefaultScale",
-        "description": "DNG default scale",
-        "long_description": "The DefaultScale field contains a pair of scale factors for cameras with non-square pixels.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 21",
-        "count": "2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC61F",
-        "name": "DefaultCropOrigin",
-        "description": "DNG default crop origin",
-        "long_description": "The DefaultCropOrigin field contains a pair of coordinates the mark the origin, in raw image coordinates.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 22",
-        "count": "2",
-        "dtype": [
-            "SHORT",
-            "LONG",
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC620",
-        "name": "DefaultCropSize",
-        "description": "DNG default crop size",
-        "long_description": "The DefaultCropSize field contains a pair of coordinates that mark the extent, in raw image coordinates.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 23",
-        "count": "2",
-        "dtype": [
-            "SHORT",
-            "LONG",
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC621",
-        "name": "ColorMatrix1",
-        "description": "DNG color matrix, set one",
-        "long_description": "The ColorMatrix1 field contains a transformation matrix to convert CIE XYZ values to reference camera native color space values, under the illuminant specified as CalibrationIlluminant1. The matrix values are stored in row scan order.",
-        "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 24",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC622",
-        "name": "ColorMatrix2",
-        "description": "DNG color matrix, set two",
-        "long_description": "The ColorMatrix2 field contains a transformation matrix to convert CIE XYZ values to reference camera native color space values, under the illuminant specified as CalibrationIlluminant2. The matrix values are stored in row scan order.",
-        "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 25",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC623",
-        "name": "CameraCalibration1",
-        "description": "DNG camera calibration, set one",
-        "long_description": "The CameraCalibration1 field contains a transformation matrix to convert reference camera native color space values to individual camera native color space samples, under the illuminant specified as CalibrationIlluminant1. The matrix is stored in row scan order.",
-        "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 25",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC624",
-        "name": "CameraCalibration2",
-        "description": "DNG camera calibration, set two",
-        "long_description": "The CameraCalibration2 field contains a transformation matrix to convert reference camera native color space values to individual camera native color space samples, under the illuminant specified as CalibrationIlluminant2. The matrix is stored in row scan order.",
-        "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 26",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC625",
-        "name": "ReductionMatrix1",
-        "description": "DNG reduction matrix, set one",
-        "long_description": "The ReductionMatrix1 contains a dimensionality reduction matrix for use as the first stage of converting camera native color space values to CIE XYZ, under the illuminant specified as CalibrationIlluminant1.",
-        "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 27",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC626",
-        "name": "ReductionMatrix2",
-        "description": "DNG reduction matrix, set two",
-        "long_description": "The ReductionMatrix2 contains a dimensionality reduction matrix for use as the first stage of converting camera native color space values to CIE XYZ, under the illuminant specified as CalibrationIlluminant2.",
-        "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 27",
-        "count": "N",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC627",
-        "name": "AnalogBalance",
-        "description": "DNG analog balance",
-        "long_description": "The AnalogBalance field contains the gain values applied to white balance.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 28",
-        "count": "N",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC628",
-        "name": "AsShotNeutral",
-        "description": "DNG neutral white balance value",
-        "long_description": "The AsShotNeutral fields contains the neutral white balance color in linear reference color space values.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 28",
-        "count": "N",
-        "dtype": [
-            "SHORT",
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC629",
-        "name": "AsShotWhiteXY",
-        "description": "DNG selected white balance",
-        "long_description": "The AsShotWhiteXY field contains xy chromaticity coordinates of the white balance.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 29",
-        "count": "2",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62A",
-        "name": "BaselineExposure",
-        "description": "DNG baseline exposure",
-        "long_description": "The BaselineExposure field contains the zero point for footroom, in EV units.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 29",
-        "count": "1",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62B",
-        "name": "BaselineNoise",
-        "description": "DNG baseline noise",
-        "long_description": "The BaselineNoise fields contains the relative noise of a camera at ISO 100 compared to the noise of a reference camera model.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 30",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62C",
-        "name": "BaselineSharpness",
-        "description": "DNG baseline sharpness",
-        "long_description": "The BaselineSharpness field contains the relative sharpening required for the camera model, compared to that of a reference camera model.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 30",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62D",
-        "name": "BayerGreenSplit",
-        "description": "DNG Bayer green split",
-        "long_description": "The BayerGreenSplit field contains a value in arbitrary units relating the tracking of the green pixels of the blue/green rows to those in red/green rows, only in color filter arrays using a Bayer pattern filter array.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 31",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62E",
-        "name": "LinearResponseLimit",
-        "description": "DNG linear response limit",
-        "long_description": "The LinearResponseLimit field specifies the range of linear sensor response.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 31",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC62F",
-        "name": "CameraSerialNumber",
-        "description": "DNG camera serial number",
-        "long_description": "The CameraSerialNumber contains the serial number of the camera or camera body.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 32",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC630",
-        "name": "LensInfo",
-        "description": "DNG lens information",
-        "long_description": "The LensInfo field contains values describing the focal length and F-stop of the lens used. The first and second values specify minimum and maximum focal length in millimeters, the third and fourth values specify minimum and maximum F-stop at minimum and maximum focal length and maximum and minimum aperture.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 32",
-        "count": "4",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC631",
-        "name": "ChromaBlurRadius",
-        "description": "DNG chroma blur radius",
-        "long_description": "The ChromaBlurRadius field contains a value specifying the chroma blur area.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 33",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC632",
-        "name": "AntiAliasStrength",
-        "description": "DNG anti-alias strength",
-        "long_description": "The AntiAliasStrength field denotes the relative strength of the camera's anti-alias filter, from 0.0 (no anti-aliasing filter) to 1.0 (effective anti-alias filter).",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 33",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC634",
-        "name": "DNGPrivateData",
-        "description": "DNG private data field",
-        "long_description": "The DNGPrivateData field contains private data.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 34",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "BLOB"
-        }
-    },
-    {
-        "tag": "0xC635",
-        "name": "MakerNoteSafety",
-        "description": "DNG makernote safety",
-        "long_description": "The MakerNoteSafety field denotes whether it is safe to copy the meaningful contents of the MakerNote in editing the file.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 35",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unsafe": "0",
-                "Safe": "1"
-            }
-        }
-    },
-    {
-        "tag": "0xC65A",
-        "name": "CalibrationIlluminant1",
-        "description": "DNG calibration illuminant, set one",
-        "long_description": "The CalibrationIlluminantField1 field denotes the light source for the first calibration set.",
-        "references": "See also<a href=\"#LightSource\">LightSource</a>, <a href=\"#ColorMatrix1\">ColorMatrix1</a>, <a href=\"#CameraCalibration1\">CameraCalibration1</a>, <a href=\"#ReductionMatrix1\">ReductionMatrix1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 23",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unidentified": "0",
-                "Daylight": "1",
-                "Fluorescent": "2",
-                "Tungsten": "3",
-                "Flash": "4",
-                "FineWeather": "9",
-                "CloudyWeather": "10",
-                "Shady": "11",
-                "DaylightFluorescent": "12",
-                "DayWhiteFluorescent": "13",
-                "CoolWhiteFluorescent": "14",
-                "WhiteFluorescent": "15",
-                "StandardIlluminantA": "17",
-                "StandardIlluminantB": "18",
-                "StandardIlluminantC": "19",
-                "D55Illuminant": "20",
-                "D65Illuminant": "21",
-                "D75Illuminant": "22",
-                "D50Illuminant": "23",
-                "ISOStudioTungsten": "24",
-                "Other": "255"
-            }
-        }
-    },
-    {
-        "tag": "0xC65B",
-        "name": "CalibrationIlluminant2",
-        "description": "DNG calibration illuminant, set two",
-        "long_description": "The CalibrationIlluminantField1 field denotes the light source for the second calibration set.",
-        "references": "See also<a href=\"#LightSource\">LightSource</a>, <a href=\"#ColorMatrix2\">ColorMatrix2</a>, <a href=\"#CameraCalibration2\">CameraCalibration2</a>, <a href=\"#ReductionMatrix2\">ReductionMatrix2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 24",
-        "count": "1",
-        "dtype": [
-            "SHORT"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "Unidentified": "0",
-                "Daylight": "1",
-                "Fluorescent": "2",
-                "Tungsten": "3",
-                "Flash": "4",
-                "FineWeather": "9",
-                "CloudyWeather": "10",
-                "Shady": "11",
-                "DaylightFluorescent": "12",
-                "DayWhiteFluorescent": "13",
-                "CoolWhiteFluorescent": "14",
-                "WhiteFluorescent": "15",
-                "StandardIlluminantA": "17",
-                "StandardIlluminantB": "18",
-                "StandardIlluminantC": "19",
-                "D55Illuminant": "20",
-                "D65Illuminant": "21",
-                "D75Illuminant": "22",
-                "D50Illuminant": "23",
-                "ISOStudioTungsten": "24",
-                "Other": "255"
-            }
-        }
-    },
-    {
-        "tag": "0xC65C",
-        "name": "BestQualityScale",
-        "description": "DNG best-quality scale factor",
-        "long_description": "The BestQualityScale field contains a value to scale the default scale factors for improved quality.",
-        "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 22",
-        "count": "1",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC660",
-        "name": "AliasLayerMetadata",
-        "description": "Alias/Wavefront layer metadata (private tag)",
-        "long_description": "The AliasLayerMetadata field contains information per the Alias Systems Multi-Layer TIFF specification.",
-        "references": "See also<a href=\"#Software\">Software</a>, <a href=\"#HostComputer\">HostComputer</a>, <a href=\"#PageName\">PageName</a>, <a href=\"#XPosition\">XPosition</a>, <a href=\"#YPosition\">YPosition</a>.",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC763",
-        "name": "TimeCodes",
-        "description": "Time Codes of the Image",
-        "long_description": "The optional TimeCodes tag shall contain an ordered array of time codes. All time codes shall be 8 bytes long and in binary format. The tag may contain from 1 to 10 time codes. When the tag contains more than one time code, the first one shall be the default time code. This specification does not prescribe how to use multiple time codes.\nEach time code shall be as defined for the 8-byte time code structure in SMPTE 331M-2004, Section 8.3. See also SMPTE 12-1-2008 and SMPTE 309-1999.",
-        "references": "CinemaDNG specification 1.1.0 p10",
-        "count": "N",
-        "dtype": [
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC764",
-        "name": "FrameRate",
-        "description": "video frame rate in number of image frames per second",
-        "long_description": "The optional FrameRate tag shall specify the video frame rate in number of image frames per second, expressed as a signed rational number. The numerator shall be non-negative and the denominator shall be positive. This field value is identical to the sample rate field in SMPTE 377-1-2009.",
-        "references": "CinemaDNG specification 1.1.0 p11",
-        "count": "1",
-        "dtype": [
-            "SRATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC772",
-        "name": "TStop",
-        "description": "T-stop of the actual lens",
-        "long_description": "The optional TStop tag shall specify the T-stop of the actual lens, expressed as an unsigned rational number. T-stop is also known as T-number or the photometric aperture of the lens. (F-number is the geometric aperture of the lens.) When the exact value is known, the T-stop shall be specified using a single number. Alternately, two numbers shall be used to indicate a T-stop range, in which case the first number shall be the minimum T-stop and the second number shall be the maximum T-stop.",
-        "references": "CinemaDNG specification 1.1.0 p11",
-        "count": "N",
-        "dtype": [
-            "RATIONAL"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC789",
-        "name": "ReelName",
-        "description": "name for a sequence of images",
-        "long_description": "The optional ReelName tag shall specify a name for a sequence of images, where each image in the sequence has a unique image identifier (including but not limited to file name, frame number, date time, time code).",
-        "references": "CinemaDNG specification 1.1.0 p11",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC7A1",
-        "name": "CameraLabel",
-        "description": "a text label for how the camera is used or assigned in this clip",
-        "long_description": "The optional CameraLabel tag shall specify a text label for how the camera is used or assigned in this clip. This tag is similar to CameraLabel in XMP.",
-        "references": "CinemaDNG specification 1.1.0 p12",
-        "count": "N",
-        "dtype": [
-            "ASCII"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC6F8",
-        "name": "ProfileName",
-        "description": "name of the camera profile",
-        "long_description": "A UTF-8 encoded string containing the name of the camera profile. This tag is optional if there is only a single camera profile stored in the file but is required for all camera profiles if there is more than one camera profile stored in the file.",
-        "references": "DNG specification 1.4.0 p53",
-        "count": "N",
-        "dtype": [
-            "ASCII",
-            "BYTE"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC6FC",
-        "name": "ProfileToneCurve",
-        "description": "tone curve that can be applied while processing the image as a starting point for user adjustments",
-        "long_description": "This tag contains a default tone curve that can be applied while processing the image as a starting point for user adjustments. The curve is specified as a list of 32-bit IEEE floating- point value pairs in linear gamma. Each sample has an input value in the range of 0.0 to 1.0, and an output value in the range of 0.0 to 1.0. The first sample is required to be (0.0, 0.0), and the last sample is required to be (1.0, 1.0). Interpolated the curve using a cubic spline.",
-        "references": "DNG specification 1.4.0 p56",
-        "count": "N",
-        "dtype": [
-            "FLOAT"
-        ],
-        "interpretation": {
-            "kind": "DEFAULT"
-        }
-    },
-    {
-        "tag": "0xC6FD",
-        "name": "ProfileEmbedPolicy",
-        "description": "usage rules for the associated camera profile",
-        "long_description": "\nThis tag contains information about the usage rules for the associated camera profile. The valid values and meanings are:\n• 0 = “allow copying”. The camera profile can be used to process, or be embedded in, any DNG file. It can be copied from DNG files to other DNG files, or copied from DNG files and stored on the user’s system for use in processing or embedding in any DNG file. The camera profile may not be used to process non-DNG files.\n• 1 = “embed if used”. This value applies the same rules as “allow copying”, except it does not allow copying the camera profile from a DNG file for use in processing any image other than the image in which it is embedded, unless the profile is already stored on the user’s system.\n• 2 = “embed never”. This value only applies to profiles stored on a user’s system but not already embedded in DNG files. These stored profiles can be used to process images but cannot be embedded in files. If a camera profile is already embedded in a DNG file, then this value has the same restrictions as “embed if used”.\n• 3 = “no restrictions”. The camera profile creator has not placed any restrictions on the use of the camera profile.",
-        "references": "DNG specification 1.4.0 p57",
-        "count": "1",
-        "dtype": [
-            "LONG"
-        ],
-        "interpretation": {
-            "kind": "ENUMERATED",
-            "values": {
-                "allow copying": "0",
-                "embed if used": "1",
-                "embed never": "2",
-                "no restrictions": "3"
-            }
-        }
+  {
+    "tag": "0x00FE",
+    "name": "NewSubfileType",
+    "description": "Subfile type (new-style)",
+    "long_description": "The NewSubfileType field contains a bitmask of intents of the IFD.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 36",
+    "count": "1",
+    "dtype": ["LONG", "SHORT"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "ReducedResolution (Reduced-resolution image data)": "bit 0",
+        "Page (Single page of a multiple page document)": "bit 1",
+        "Mask (Image mask data)": "bit 2",
+        "FP (TIFF/IT Final Page)": "bit 3",
+        "MRC (TIFF-FX Mixed Raster Content)": "bit 4"
+      }
     }
+  },
+  {
+    "tag": "0x00FF",
+    "name": "SubfileType",
+    "description": "Subfile type (old-style)",
+    "long_description": "The SubfileType field contains an enumerated value of intents of the IFD. The SubfileType field is made obsolete by NewSubfileType.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 40",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "FullResolution (Full-resolution image data)": "1",
+        "ReducedResolution (Reduced-resolution image data)": "2",
+        "Page (Single page of a multiple page document)": "3"
+      }
+    }
+  },
+  {
+    "tag": "0x0100",
+    "name": "ImageWidth",
+    "description": "Width of the image in pixels (columns)",
+    "long_description": "The ImageWidth field is the width of the image, the number of columns in the pel-path direction.",
+    "references": "See also<a href=\"#ImageLength\">ImageLength</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 34",
+    "count": "1",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0101",
+    "name": "ImageLength",
+    "description": "Length of the image in pixels (rows)",
+    "long_description": "The ImageLength field is the length of the image, the number of scanlines in the scan direction.",
+    "references": "See also<a href=\"#ImageWidth\">ImageWidth</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 34",
+    "count": "1",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0102",
+    "name": "BitsPerSample",
+    "description": "Counts of bits per sample",
+    "long_description": "The BitsPerSample field specifies the precision or number of bits that is used to represent each component of the image in an image sample. This field sometimes contains one value, for each component having the same precision, it should have a value for each component.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
+    "count": "SPP\n1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0103",
+    "name": "Compression",
+    "description": "Compression scheme",
+    "long_description": "The Compression field represents the type of compression used to compress the image data.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 30",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "None (No compression)": "1",
+        "MH (Modified Huffman compression)": "2",
+        "Group3 (T.4 compression)": "3",
+        "Group4 (T.6 (MMR) compression)": "4",
+        "LZW (LZW (Lempel-Ziv-Welch) compression)": "5",
+        "OJPEG (JPEG (old-style) compression)": "6",
+        "JPEG (JPEG (new-style) compression)": "7",
+        "JBIG (TIFF-FX JBIG (T.82) compression)": "9",
+        "JBIG_MRC (TIFF-FX JBIG (T.82) MRC (T.43) representation compression)": "10",
+        "NeXT (NeXT 2-bit grey scale compression)": "0x7FFE",
+        "Group3_1D_wordalign (Group 3 1-D (MH) compression, word-aligned)": "0x8003",
+        "Packbits (Macintosh Packbits Run-Length Encoding (RLE) compression)": "0x8005",
+        "Thunderscan (Thunderscan 4-bit compression)": "0x8029",
+        "IT8CT_MP_RasterPadding": "0x807F",
+        "IT8LW_RLE": "0x8080",
+        "IT8MP_RLE": "0x8081",
+        "IT8BL_RLE": "0x8082",
+        "PixarFilm": "0x808C",
+        "PixarLog": "0x808D",
+        "Deflate_experimental (Deflate algorithm compression (experimental value))": "0x80B2",
+        "Deflate (Deflate algorithm compression (standard value))": "0x0008",
+        "DCS": "0x80B3",
+        "JBIG_experimental": "0x8765",
+        "SGILog": "0x8774",
+        "SGILog24": "0x8775",
+        "JPEG2000_LEAD": "0x8798",
+        "JBIG2_TIFF_FX": "0x879B"
+      }
+    }
+  },
+  {
+    "tag": "0x0106",
+    "name": "PhotometricInterpretation",
+    "description": "Photometric interpretation",
+    "long_description": "The PhotometricInterpretation field describes the colorspace the image samples represent.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 37",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "WhiteIsZero (White is zero)": "0",
+        "BlackIsZero (Black is zero)": "1",
+        "RGB (RGB (Red, Green, Blue))": "2",
+        "PaletteColor (Palette color)": "3",
+        "TransparencyMask (Transparency mask)": "4",
+        "Separated (Separation)": "5",
+        "YCbCr (YCbCr)": "6",
+        "CIELab (CIE L*a*b*)": "8",
+        "ICCLab (ICC L*a*b*)": "9",
+        "ITULab (ITU-T Facsimile L*a*b*)": "10",
+        "LogL (Log luminance)": "32844",
+        "LogLUV (Log luminance and chrominance)": "32845",
+        "CFA (Color filter array)": "32803",
+        "LinearRaw (DNG Linear Raw)": "34892"
+      }
+    }
+  },
+  {
+    "tag": "0x0107",
+    "name": "Thresholding",
+    "description": "Halftone/dithering algorithm",
+    "long_description": "The Thresholding field contains the type of the halftoning/dithering algorithm used.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 41",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "NoDither": "1",
+        "OrderedDither": "2",
+        "RandomizedProcess": "3"
+      }
+    }
+  },
+  {
+    "tag": "0x0108",
+    "name": "CellWidth",
+    "description": "Width of the halftone or dither cell",
+    "long_description": "The CellWidth fields contains the width of the halftone cell. This field should only be present if Thresholding==OrderedDither.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0109",
+    "name": "CellLength",
+    "description": "Length of the halftone or dither cell",
+    "long_description": "The CellLength field contains the length of the halftone cell. This field should only be present if Thresholding==OrderedDither.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 29",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x010A",
+    "name": "FillOrder",
+    "description": "The bit order within coded image data",
+    "long_description": "The FillOrder field describes the bit order of the compressed image data. This is almost always msb-to-lsb.  The native form of Group 3 facsimile devices is lsb-to-msb.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 32",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "MSBtoLSB (most-significant-bit to least-significant-bit)": "1",
+        "LSBtoMSB (least-significant-bit to most-significant-bit)": "2"
+      }
+    }
+  },
+  {
+    "tag": "0x010D",
+    "name": "DocumentName",
+    "description": "Document name",
+    "long_description": "The DocumentName fields contains the name of the document.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x010E",
+    "name": "ImageDescription",
+    "description": "Image description",
+    "long_description": "The ImageDescription fields contains text describing the image.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x010F",
+    "name": "Make",
+    "description": "Input device make",
+    "long_description": "The Make field defines the manufacturer of the input scanner/camera that digitized the image.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0110",
+    "name": "Model",
+    "description": "Input device model",
+    "long_description": "The Model field defines the model of the input scanner/camera that digitized the image.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0111",
+    "name": "StripOffsets",
+    "description": "Offsets to strip data",
+    "long_description": "The StripOffsets field contains a value for each strip of the image that is the offset to the beginning of the strip data. The strips per image is determined from the image length and the rows per strip.  See ImageLength, RowsPerStrip. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each strip of the image, with the offsets pointing to in order the strips for each separated component.",
+    "references": "See also<a href=\"#StripByteCounts\">StripByteCounts</a>, <a href=\"#RowsPerStrip\">RowsPerStrip</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 40",
+    "count": "SPI\nSPPxSPI",
+    "dtype": ["LONG", "SHORT"],
+    "interpretation": {
+      "kind": "OFFSETS",
+      "lengths": "StripByteCounts"
+    }
+  },
+  {
+    "tag": "0x0112",
+    "name": "Orientation",
+    "description": "Orientation of image",
+    "long_description": "The Orientation field describes how the output image is to be interpreted by rotating or flipping the coordinate origin.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "RowTopColumnLeft": "1",
+        "RowTopColumnRight": "2",
+        "RowBottomColumnRight": "3",
+        "RowBottomColumnLeft": "4",
+        "RowLeftColumnTop": "5",
+        "RowRightColumnTop": "6",
+        "RowRightColumnBottom": "7",
+        "RowLeftColumnBottom": "8",
+        "Unknown": "9"
+      }
+    }
+  },
+  {
+    "tag": "0x0115",
+    "name": "SamplesPerPixel",
+    "description": "Count of samples per pixel",
+    "long_description": "The SamplesPerPixel field is how many image or data component samples there are for each pixel. Each pixel has the same number of samples, except in the case of subsampled YCbCr and ITU/Facsimile L*a*b* per TIFF 6.0 and TIFF-FX, in which case this value reflects the number of components. Each sample represents an channel or component given the photometric interpretation, unless extra samples are present.  See ExtraSamples. The image may have multiple components but be a palettized image, in which case SamplesPerPixel would only reflect one sample for the color map entry.  See Indexed, PhotometricInterpretation==PaletteColor.",
+    "references": "See also<a href=\"#ExtraSamples\">ExtraSamples</a>, <a href=\"#Indexed\">Indexed</a>, <a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 39",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0116",
+    "name": "RowsPerStrip",
+    "description": "Rows per strip",
+    "long_description": "The RowsPerStrip field contains the number of rows (scanlines) per strip. It is used to determine the strips per image. A value of 0xFFFFFFFF, or the maximum value of the data type, implies that the entire image is one strip.",
+    "references": "See also<a href=\"#StripOffsets\">StripOffsets</a>, <a href=\"#StripByteCounts\">StripByteCounts</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 39",
+    "count": "1",
+    "dtype": ["LONG", "SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0117",
+    "name": "StripByteCounts",
+    "description": "Byte counts of strip data",
+    "long_description": "The StripByteCounts field contains a value for each strip of the image that is the byte count of the strip. The strips per image is determined from the image length and the rows per strip.  See ImageLength, RowsPerStrip. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each strip of the image, with the offsets pointing to in order the strips for each separated component.",
+    "references": "See also<a href=\"#StripOffsets\">StripOffsets</a>, <a href=\"#RowsPerStrip\">RowsPerStrip</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 40",
+    "count": "SPI\nSPPxSPI",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "LENGTHS"
+    }
+  },
+  {
+    "tag": "0x0118",
+    "name": "MinSampleValue",
+    "description": "Minimum sample value",
+    "long_description": "The MinSampleValue field identifies the least sample value for each sample, from the range of values possible given the bits per sample of the sample as an unsigned integer. This is for use only for statistical purposes and not footroom of the sample.",
+    "references": "See also<a href=\"#MaxSampleValue\">MaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 36",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0119",
+    "name": "MaxSampleValue",
+    "description": "Maximum sample value",
+    "long_description": "The MaxSamplesValue field identifies the greatest sample value for each sample, from the range of values possible given the bits per sample of the sample as an unsigned integer. This is for use only for statistical purposes and not headroom of the sample.",
+    "references": "See also<a href=\"#MinSampleValue\">MinSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 36",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x011A",
+    "name": "XResolution",
+    "description": "Horizontal resolution",
+    "long_description": "The XResolution contains the pixels per resolution unit in the horizontal direction, before orientation.",
+    "references": "See also<a href=\"#YResolution\">YResolution</a>, <a href=\"#ResolutionUnit\">ResolutionUnit</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x011B",
+    "name": "YResolution",
+    "description": "Vertical resolution",
+    "long_description": "The YResolution contains the pixels per resolution unit in the vertical direction, before orientation.",
+    "references": "See also<a href=\"#XResolution\">XResolution</a>, <a href=\"#ResolutionUnit\">ResolutionUnit</a>, <a href=\"#Orientation\">Orientation</a>. <a href=\"#TIFF6\">TIFF6</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x011C",
+    "name": "PlanarConfiguration",
+    "description": "Configuration of data interleaving",
+    "long_description": "The PlanarConfiguration field describes how the data is interleaved, for example pixel interleaved, scanline interleaved, or component interleaved.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 38",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Chunky (Chunky (component interleaved) sample organization)": "1",
+        "Planar (Planar (channel interleaved) sample organization)": "2",
+        "Line (Line (line interleaved) sample organization (IT8))": "0x8000"
+      }
+    }
+  },
+  {
+    "tag": "0x011D",
+    "name": "PageName",
+    "description": "Page name",
+    "long_description": "The PageName field contains the name of a page within a multiple-page document, for example a logical page number.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x011E",
+    "name": "XPosition",
+    "description": "Horizontal positional offset",
+    "long_description": "The XPosition field defines the horizontal offset from the edge of an output page of the image data. The XPosition field is used in TIFF-FX MRC to define the offset of image elements in MRC.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55\n <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x011F",
+    "name": "YPosition",
+    "description": "Vertical positional offset",
+    "long_description": "The YPosition field defines the vertical offset from the edge of an output page of the image data. The YPosition field is used in TIFF-FX MRC to define the offset of image elements in MRC.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 56\n <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0120",
+    "name": "FreeOffsets",
+    "description": "Offsets to unused file areas",
+    "long_description": "The FreeOffsets field contains an array of offsets to unused regions within the file.",
+    "references": "",
+    "count": "N",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "OFFSETS",
+      "lengths": "FreeByteCounts"
+    }
+  },
+  {
+    "tag": "0x0121",
+    "name": "FreeByteCounts",
+    "description": "Byte counts of unused file areas",
+    "long_description": "The FreeOffsets field contains an array of byte counts of unused regions within the file.",
+    "references": "",
+    "count": "N",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "LENGTHS"
+    }
+  },
+  {
+    "tag": "0x0122",
+    "name": "GrayResponseUnit",
+    "description": "Grayscale response curve units",
+    "long_description": "The GrayResponseUnit field contains a value describing the multiplier of the GrayResponseCurve values.  Each GrayResponseCurve value is multiplied by the value of the GrayResponseUnit, eg 1/10, 1/100, 1/1000, etcetera.",
+    "references": "See also<a href=\"#GrayResponseCurve\">GrayResponseCurve</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 33",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Tenths": "1",
+        "Hundredths": "2",
+        "Thousandths": "3",
+        "TenThousandths": "4",
+        "HundredThousandths": "5"
+      }
+    }
+  },
+  {
+    "tag": "0x0123",
+    "name": "GrayResponseCurve",
+    "description": "Grayscale response curve",
+    "long_description": "The GrayResponseCurve contains a value for each of the values of BitsPerSample many bits that describes the optical density of a pixel having that value. The values of the GrayResponseCurve are each to be multiplied by the factor described in the GrayResponseUnits field.",
+    "references": "See also<a href=\"#GrayResponseUnit\">GrayResponseUnit</a>, <a href=\"#ColorResponseCurves\">ColorResponseCurves</a>, <a href=\"#TransferFunction\">TransferFunction</a>. <a href=\"#TIFF6\">TIFF6</a>, p. 33",
+    "count": "2toBPS",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0124",
+    "name": "T4Options",
+    "description": "Group 3 Fax options",
+    "long_description": "The T4Options field contains options of the ITU-T T.4 (CCITT Group 3 Facsmile) coding.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 11:  CCITT Bilevel Encodings\", p. 51",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "2D": "bit 0",
+        "UncompressedMode": "bit 1",
+        "EOLByteAlign": "bit 2"
+      }
+    }
+  },
+  {
+    "tag": "0x0125",
+    "name": "T6Options",
+    "description": "Group 4 Fax options",
+    "long_description": "The T6Options field contains options of the ITU-T T.6 (CCITT Group 4 Facsmile) coding.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 11:  CCITT Bilevel Encodings\", p. 52",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "UncompressedMode": "bit 1"
+      }
+    }
+  },
+  {
+    "tag": "0x0128",
+    "name": "ResolutionUnit",
+    "description": "Resolution units",
+    "long_description": "The ResolutionUnit field contains whether the resolution unit is inch, centimeter, or unknown/unspecified.",
+    "references": "See also<a href=\"#XResolution\">XResolution</a>, <a href=\"#YResolution\">YResolution</a>. <a href=\"#TIFF6\">TIFF6</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unitless (Units not specified)": "1",
+        "Inch (Units in inches)": "2",
+        "Centimeter (Units in centimeters)": "3"
+      }
+    }
+  },
+  {
+    "tag": "0x0129",
+    "name": "PageNumber",
+    "description": "Page number",
+    "long_description": "The PageNumber field contains two values, the first being the page index for this page and the second being the number of pages or zero for unknown.  Some broken applications reverse these values.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 12:  Document Storage and Retrieval\", p. 55",
+    "count": "2",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x012C",
+    "name": "ColorResponseUnit",
+    "description": "Color response curve units",
+    "long_description": "The ColorResponseUnit field contains a value describing the multiplier of the ColorResponseCurves values.  Each of the ColorResponseCurves' values is multiplied by the value of the ColorResponseUnit, eg 1/10, 1/100, 1/1000, etcetera.",
+    "references": "See also<a href=\"#ColorResponseCurves\">ColorResponseCurves</a>. <a href=\"#TIFF4\">TIFF4</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Tenths": "1",
+        "Hundredths": "2",
+        "Thousandths": "3",
+        "TenThousandths": "4",
+        "HundredThousandths": "5"
+      }
+    }
+  },
+  {
+    "tag": "0x012D",
+    "name": "TransferFunction",
+    "description": "Transfer function",
+    "long_description": "The TransferFunction field contains a value for each of the possible values of the pixel for each component or all components. The TransferFunction tag coincides with the ColorResponseCurves tag, if the ColorResponseUnits field exists then TransferFunction should be treated as ColorResponseCurves.",
+    "references": "See also<a href=\"#TransferRange\">TransferRange</a>, <a href=\"#ReferenceBlackWhite\">ReferenceBlackWhite</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 84",
+    "count": "2toBPS\n3x2toBPS",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0131",
+    "name": "Software",
+    "description": "Software version",
+    "long_description": "The Software field defines the software product and version that generated the image file.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0132",
+    "name": "DateTime",
+    "description": "Date and time of image creation",
+    "long_description": "The DateTime contains an ASCII string of 20 characters, with the ending binary zero. The ASCII string encodes a date and time as \"YYYY:MM:DD HH:MM:SS\".",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "20",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DATETIME"
+    }
+  },
+  {
+    "tag": "0x013B",
+    "name": "Artist",
+    "description": "Person who created the image",
+    "long_description": "The Artist field contains the artist/author of the image. This field is sometimes used to hold copyright information. This field sometimes contains two null-terminated strings, with the second being copyright information.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x013C",
+    "name": "HostComputer",
+    "description": "Host computer",
+    "long_description": "The HostComputer field contains the name of the computer which created the image file.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x013D",
+    "name": "Predictor",
+    "description": "Differencing predictor",
+    "long_description": "The Predictor field describes the differencing predictor method used. It is used with LZW and perhaps also Deflate compression schemes.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 14: Differencing Predictor\", p. 64",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "NoPrediction (No prediction sheme)": "1",
+        "HorizontalDifferencing (Horizontal differencing prediction scheme)": "2"
+      }
+    }
+  },
+  {
+    "tag": "0x013E",
+    "name": "WhitePoint",
+    "description": "Chromaticity of white point",
+    "long_description": "The WhitePoint field contains two values that describe the CIE xy components of the chromaticity of the white point, where the primaries (channels) have their reference white values.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 83",
+    "count": "2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x013F",
+    "name": "PrimaryChromaticities",
+    "description": "Chromaticities of primaries",
+    "long_description": "The PrimaryChromaticities field contains six values that described the CIE xy components of the chromaticity of the three primaries (channels) at their reference white values, where the other primaries are at their reference black values.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 83",
+    "count": "6",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0140",
+    "name": "ColorMap",
+    "description": "Color map/palette",
+    "long_description": "The ColorMap field contains a 16-bit value for each component. The values are component interleaved, for example for an RGB images the values of the colormap are stored RRR...GGG...BBB.... The colormap may contain a map for three or four component images, when either PhotometricInterpretation==PaletteColor or Indexed==Indexed.",
+    "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>, <a href=\"#Indexed\">Indexed</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 5:  Palette-color Images\", p. 23",
+    "count": "SPPx2toBPS",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "COLORMAP"
+    }
+  },
+  {
+    "tag": "0x0141",
+    "name": "HalftoneHints",
+    "description": "Halftone hints",
+    "long_description": "The HalftoneHints field contains range extents for the halftone function of values to retain tonal value.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 17:  HalftoneHints\", p. 72",
+    "count": "2",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0142",
+    "name": "TileWidth",
+    "description": "Tile width",
+    "long_description": "The TileWidth field contains the width of the tiles of the tiled image. TileWidth must be a multiple of 16.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
+    "count": "1",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0143",
+    "name": "TileLength",
+    "description": "Tile length",
+    "long_description": "The TileLength field contains the length of the tiles in the tiled image. TileLength must be a multiple of 16.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
+    "count": "1",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0144",
+    "name": "TileOffsets",
+    "description": "Offsets to tile data",
+    "long_description": "The TileOffsets field contains a value for each tile that is the offset to the beginning of the tile data. The tiles per image is determined from the image dimensions and the tile dimensions.  See ImageWidth, ImageLength, TileWidth, TileLength. The tiles are in order from left-to-right and then top-to-bottom. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each tile of the image, with the offsets pointing to in order the tiles for each separated component.",
+    "references": "See also<a href=\"#TileByteCounts\">TileByteCounts</a>, <a href=\"#TileWidth\">TileWidth</a>, <a href=\"#TileLength\">TileLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
+    "count": "TPI\nSPPxTPI",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "OFFSETS",
+      "lengths": "TileByteCounts"
+    }
+  },
+  {
+    "tag": "0x0145",
+    "name": "TileByteCounts",
+    "description": "Byte counts of tile data",
+    "long_description": "The TileByteCounts field contains a value for each tile that is the offset to the beginning of the tile data. The tiles per image is determined from the image dimensions and the tile dimensions.  See ImageWidth, ImageLength, TileWidth, TileLength. The tiles are in order from left-to-right and then top-to-bottom. If the image has PlanarConfiguration==Planar then there is an offset for each sample for each tile of the image, with the offsets pointing to in order the tiles for each separated component.",
+    "references": "See also<a href=\"#TileOffsets\">TileOffsets</a>, <a href=\"#TileWidth\">TileWidth</a>, <a href=\"#TileLength\">TileLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 15:  Tiled Images\", p. 66",
+    "count": "TPI\nSPPxTPI",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "LENGTHS"
+    }
+  },
+  {
+    "tag": "0x0146",
+    "name": "BadFaxLines",
+    "description": "Bad received fax lines",
+    "long_description": "The BadFaxLines field contains how many of the ImageLength many rows were damaged on facsimile transmission.",
+    "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
+    "count": "1",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0147",
+    "name": "CleanFaxData",
+    "description": "Fax data cleanliness",
+    "long_description": "The CleanFaxData field describes the damaged or undamaged state of transmitted Group 3 facsimile data.",
+    "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Clean": "0",
+        "Regenerated": "1",
+        "Unregenerated": "2"
+      }
+    }
+  },
+  {
+    "tag": "0x0148",
+    "name": "ConsecutiveBadFaxLines",
+    "description": "Maximum consecutive bad fax lines",
+    "long_description": "The ConsecutiveBadFaxLines field contains the maximum of how many facsimile lines in a row were damaged or unreadable on transmission.",
+    "references": "<a href=\"#TIFFSF\">TIFFSF</a>",
+    "count": "1",
+    "dtype": ["LONG", "SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x014A",
+    "name": "SubIFDs",
+    "description": "Offsets to child IFDs",
+    "long_description": "The SubIFDs fields contains offsets to child IFDs of the current IFD that are not otherwise linked in the IFD chain.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 2:  TIFF Structure\", p. 14\n <a href=\"#TTN1\">TTN1</a> \n <a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 1:  TIFF Trees\", p. 4",
+    "count": "N",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "IFDOFFSET",
+      "ifd_type": "IFD"
+    }
+  },
+  {
+    "tag": "0x014C",
+    "name": "InkSet",
+    "description": "Ink set",
+    "long_description": "The InkSet field for separated images describes whether the inkset is CMYK, or not.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "CMYK (CMYK inkset)": "1",
+        "NotCMYK (Not a CMYK inkset)": "2"
+      }
+    }
+  },
+  {
+    "tag": "0x014D",
+    "name": "InkNames",
+    "description": "Ink names",
+    "long_description": "The InkNames field contains a null-separated list of strings that define ink/colorant names. The number of strings must be equal to the value of the NumberOfInks field.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "MULTIPLEASCII"
+    }
+  },
+  {
+    "tag": "0x014E",
+    "name": "NumberOfInks",
+    "description": "Ink count",
+    "long_description": "The NumberOfInks fields contains the number of inks for a separated image.",
+    "references": "See also<a href=\"#InkSet\">InkSet</a>, <a href=\"#InkNames\">InkNames</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 70",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0150",
+    "name": "DotRange",
+    "description": "Ink range limits",
+    "long_description": "The DotRange value contains the value of the sample for 0% and 100% saturation, for either all samples or each sample.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 71",
+    "count": "2\n2xSPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0151",
+    "name": "TargetPrinter",
+    "description": "Target printer",
+    "long_description": "The TargetPrinter describes the output printer environment.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 16:  CMYK Images\", p. 71",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0152",
+    "name": "ExtraSamples",
+    "description": "Description of extra components",
+    "long_description": "The ExtraSamples field defines how many data samples there are beyond those for the photometric interpretation. There may be extra components of the image beyond those for the PhotometricInterpretation.  These components are often used to represent transparency information of the samples. For each of the N many extra components, the value of this field represents the meaning of the extra sample.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, p. 31\n <a href=\"#TIFF6\">TIFF6</a>, p. 69\n <a href=\"#TIFF6\">TIFF6</a>, p. 77",
+    "count": "N",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unspecified (Unspecified data)": "0x0000",
+        "AssociatedAlpha (Associated alpha (transparency), premultiplied)": "0x0001",
+        "UnassociatedAlpha (Unassociated alpha (transparency))": "0x0002"
+      }
+    }
+  },
+  {
+    "tag": "0x0153",
+    "name": "SampleFormat",
+    "description": "Format of data sample",
+    "long_description": "The SampleFormat field represents for each sample the data format of the sample, whether unsigned or signed integer, floating point, or undefined.  The bits per sample are determined by the BitsPerSample field. The default is unsigned integer data, and undefined data should be left or treated as unsigned integer data.",
+    "references": "See also<a href=\"#BitsPerSample\">BitsPerSample</a>, <a href=\"#SMinSampleValue\">SMinSampleValue</a>, <a href=\"#SMaxSampleValue\">SMaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "UnsignedInteger (Unsigned integer data)": "1",
+        "SignedInteger (Signed (two's complement) integer data)": "2",
+        "FloatingPoint (IEEE floating point data)": "3",
+        "Undefined (Undefined sample format)": "4"
+      }
+    }
+  },
+  {
+    "tag": "0x0154",
+    "name": "SMinSampleValue",
+    "description": "Minimum sample value of data format",
+    "long_description": "The SMinSampleValue field identifies the least sample value for each sample, from the range of values possible given the bits per sample of the sample as its type as specified by the SampleFormat field.",
+    "references": "See also<a href=\"#SMaxSampleValue\">SMaxSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
+    "count": "SPP",
+    "dtype": [
+      "LONG",
+      "SHORT",
+      "BYTE",
+      "SLONG",
+      "SSHORT",
+      "SBYTE",
+      "DOUBLE",
+      "FLOAT"
+    ],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0155",
+    "name": "SMaxSampleValue",
+    "description": "Maximum sample value of data format",
+    "long_description": "The SMaxSampleValue field identifies the greatest sample value for each sample, from the range of values possible given the bits per sample of the sample as its type as specified by the SampleFormat field.",
+    "references": "See also<a href=\"#SMinSampleValue\">SMinSampleValue</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 19:  Data Sample Format\", p. 80",
+    "count": "SPP",
+    "dtype": [
+      "LONG",
+      "SHORT",
+      "BYTE",
+      "SLONG",
+      "SSHORT",
+      "SBYTE",
+      "DOUBLE",
+      "FLOAT"
+    ],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0156",
+    "name": "TransferRange",
+    "description": "Transfer range",
+    "long_description": "The TransferRange field contains two values for each of three components that are an offset and a scaling, these values expand the TransferFunction range.",
+    "references": "See also<a href=\"#TransferFunction\">TransferFunction</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 85",
+    "count": "6",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0157",
+    "name": "ClipPath",
+    "description": "Clipping path",
+    "long_description": "The ClipPath field contains the specification of a clipping path that outlines the image data to be output. The TIFF clipping path is designed to be directly compatible with PostScript path information. The clip path contains a header, 16 bytes with \"II\" or \"MM\" and then zeros, and then path operators, commands.",
+    "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6\n <a href=\"#PLRM\">PLRM</a>",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "PSCLIPPATH"
+    }
+  },
+  {
+    "tag": "0x0158",
+    "name": "XClipPathUnits",
+    "description": "Clipping path horizontal units",
+    "long_description": "The XClipPathUnits field contains the number of horizontal clip path coordinates, the count of coordinates for the clip path coordinate system across the image.",
+    "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0159",
+    "name": "YClipPathUnits",
+    "description": "Clipping path vertical units",
+    "long_description": "The YClipPathUnits field contains the number of vertical clip path coordinates, the count of coordinates for the clip path coordinate system down the image.",
+    "references": "<a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 2:  Clipping Path\", p. 6",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x015A",
+    "name": "Indexed",
+    "description": "Indexed (palettized) image",
+    "long_description": "The Indexed field denotes whether the image data given the photometric interpretation (see PhotometricInterpretation) is palettized or indexed to the color map (see ColorMap).",
+    "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>, <a href=\"#ColorMap\">ColorMap</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, \"TIFF Tech Note 3:  Indexed Images\", p. 11\n <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "NotIndexed (Not indexed)": "0x0000",
+        "Indexed (Indexed)": "0x0001"
+      }
+    }
+  },
+  {
+    "tag": "0x015B",
+    "name": "JPEGTables",
+    "description": "Contents of new JPEG tables",
+    "long_description": "The JPEGTables field contains an abbreviated JPEG data table specification to install the tables into the JPEG coder for JPEG coded data.",
+    "references": "<a href=\"#TTN2\">TTN2</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "JPEGTABLES"
+    }
+  },
+  {
+    "tag": "0x015F",
+    "name": "OPIProxy",
+    "description": "OPI proxy indicator",
+    "long_description": "The OPIProxy field denotes whether this image is a proxy for a higher resolution image named in the ImageID field.",
+    "references": "See also<a href=\"#ImageID\">ImageID</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, p. 15\n <a href=\"#OPI2\">OPI2</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0181",
+    "name": "Decode",
+    "description": "TIFF-FX decode array",
+    "long_description": "The Decode field contains values that define the range of colorspace values to map the range of sample values.",
+    "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "2xSPP",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DECODEARRAY"
+    }
+  },
+  {
+    "tag": "0x0182",
+    "name": "DefaultImageColor",
+    "description": "TIFF-FX default image color",
+    "long_description": "The DefaultImageColor field contains the samples of a pixel that define the default image color in TIFF-FX MRC image data.",
+    "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0190",
+    "name": "GlobalParametersIFD",
+    "description": "TIFF-FX IFD offset for global parameters",
+    "long_description": "The GlobalParametersIFD field is to contain an offset to a child IFD that contains fields with global parameters of the TIFF-FX profile file. The GlobalParametersIFD field should be written to the first IFD of the TIFF-FX file.  The global parameters IFD should contain ProfileType, FaxProfile, CodingMethods, VersionYear, and ModeNumber fields.",
+    "references": "See also<a href=\"#ProfileType\">ProfileType</a>, <a href=\"#FaxProfile\">FaxProfile</a>, <a href=\"#CodingMethods\">CodingMethods</a>, <a href=\"#VersionYear\">VersionYear</a>, <a href=\"#ModeNumber\">ModeNumber</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "IFDOFFSET",
+      "ifd_type": "IFD"
+    }
+  },
+  {
+    "tag": "0x0191",
+    "name": "ProfileType",
+    "description": "TIFF-FX profile type",
+    "long_description": "The ProfileType field describes the profile of data in the TIFF file.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unspecified": "0",
+        "Group3Fax": "1"
+      }
+    }
+  },
+  {
+    "tag": "0x0192",
+    "name": "FaxProfile",
+    "description": "TIFF-FX fax profile",
+    "long_description": "The FaxProfile field describes the TIFF-FX profile of data in the TIFF file.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#MultiProfiles\">MultiProfiles</a>. <a href=\"#TIFFFX\">TIFFFX</a> \n <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "NotProfile": "0",
+        "ProfileS": "1",
+        "ProfileF": "2",
+        "ProfileJ": "3",
+        "ProfileC": "4",
+        "ProfileL": "5",
+        "ProfileM": "6",
+        "ProfileT": "7",
+        "MultiProfiles": "255"
+      }
+    }
+  },
+  {
+    "tag": "0x0193",
+    "name": "CodingMethods",
+    "description": "TIFF-FX coding methods",
+    "long_description": "The CodingMethods field describes the coding methods used on the data in the TIFF-FX file.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "Unspecified": "bit 0",
+        "Group3_1D": "bit 1",
+        "Group3_2D": "bit 2",
+        "Group4": "bit 3",
+        "JBIG": "bit 4",
+        "JPEG": "bit 5",
+        "JBIGColor": "bit 6"
+      }
+    }
+  },
+  {
+    "tag": "0x0194",
+    "name": "VersionYear",
+    "description": "TIFF-FX version year",
+    "long_description": "The VersionYear field contains four characters forming the ASCII representation of the TIFF-FX version.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "4",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "FOURBYTEASCII"
+    }
+  },
+  {
+    "tag": "0x0195",
+    "name": "ModeNumber",
+    "description": "TIFF-FX mode number",
+    "long_description": "The ModeNumber field describes the mode of the standard used by the TIFF-FX FaxProfile field.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#FaxProfile\">FaxProfile</a>. <a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Version_1_0 (FaxProfile Mode 1.0)": "0"
+      }
+    }
+  },
+  {
+    "tag": "0x01B3",
+    "name": "T82Options",
+    "description": "TIFF-FX T.82 options",
+    "long_description": "The T82Options field contains options of the ITU-T T.82 (JBIG) coding.",
+    "references": "<a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {}
+    }
+  },
+  {
+    "tag": "0x0200",
+    "name": "JPEGProc",
+    "description": "JPEG Process",
+    "long_description": "The JPEGProc field defines the JPEG process used to compress the image data, as either baseline sequential or lossless.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 104",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "BaselineSequential (Baseline sequential JPEG process)": "1",
+        "LosslessHuffman (Lossless JPEG process with Huffman encoding)": "14"
+      }
+    }
+  },
+  {
+    "tag": "0x0201",
+    "name": "JPEGInterchangeFormat",
+    "description": "Offset to JPEG interchange format",
+    "long_description": "The JPEGInterchangeFormat field contains an offset to the beginning of a block of JPEG interchange format data.",
+    "references": "See also<a href=\"#JPEGInterchangeFormatLength\">JPEGInterchangeFormatLength</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "OFFSETS",
+      "lengths": "JPEGInterchangeFormatLength"
+    }
+  },
+  {
+    "tag": "0x0202",
+    "name": "JPEGInterchangeFormatLength",
+    "description": "Byte count of JPEG interchange format",
+    "long_description": "The JPEGInterchangeFormatLength describes the extent of a block of JPEG interchange format data from the offset of the data.",
+    "references": "See also<a href=\"#JPEGInterchangeFormat\">JPEGInterchangeFormat</a>. <a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "LENGTHS"
+    }
+  },
+  {
+    "tag": "0x0203",
+    "name": "JPEGRestartInterval",
+    "description": "JPEG restart interval",
+    "long_description": "The JPEGRestartInterval field contains the value of the restart interval of the JPEG coded data.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 105",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0205",
+    "name": "JPEGLosslessPredictors",
+    "description": "JPEG lossless predictors",
+    "long_description": "The JPEGLosslessPredictors field contains a list of the lossless predictor selection values of the JPEG coded data.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 106",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0206",
+    "name": "JPEGPointTransforms",
+    "description": "JPEG point transforms",
+    "long_description": "The JPEGPointTransforms field contains a list of the point transforms of the JPEG coded data.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 106",
+    "count": "SPP",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0207",
+    "name": "JPEGQTables",
+    "description": "Offsets to JPEG quantization tables",
+    "long_description": "The JPEGQTables field contains a list of offsets to quantization tables of the JPEG coded data. Each table is 64 bytes in extent.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
+    "count": "SPP",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "JPEGQTABLES"
+    }
+  },
+  {
+    "tag": "0x0208",
+    "name": "JPEGDCTables",
+    "description": "Offsets to JPEG DC tables",
+    "long_description": "The JPEGDCTables field contains a list of offsets to Huffman DC tables of the JPEG coded data. The extent of each is 16 bytes plus the sum of the values in those 16 bytes.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
+    "count": "SPP",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "JPEGHTABLES"
+    }
+  },
+  {
+    "tag": "0x0209",
+    "name": "JPEGACTables",
+    "description": "Offsets to JPEG AC tables",
+    "long_description": "The JPEGACTables field contains a list of offsets to Huffman AC tables of the JPEG coded data. The extent of each is 16 bytes plus the sum of the values in those 16 bytes.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 22:  JPEG Compression\", p. 107",
+    "count": "SPP",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "JPEGHTABLES"
+    }
+  },
+  {
+    "tag": "0x0211",
+    "name": "YCbCrCoefficients",
+    "description": "Transformation from RGB to YCbCr",
+    "long_description": "The YCbCrCoefficients fields specifies three fractions that represent the coefficients used to generate the luminance channel, Y, of YCbCr data, from RGB data.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 90",
+    "count": "3",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0212",
+    "name": "YCbCrSubSampling",
+    "description": "Chrominance component subsampling",
+    "long_description": "The YCbCrSubSampling field contains a value for both of two chromaticity components that describes the horizontal subsampling frequency and the vertical subsampling frequency, horizontal in the first value and vertical in the second value.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 91",
+    "count": "2",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x0213",
+    "name": "YCbCrPositioning",
+    "description": "Position of chrominance to luminance samples",
+    "long_description": "The YCbCrPositioning field describes whether the chrominance channels are centered among the luminance channels or cosited upon subsampling of the chrominance channels.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 21:  YCbCr Images\", p. 92",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Centered": "1",
+        "Cosited": "2"
+      }
+    }
+  },
+  {
+    "tag": "0x0214",
+    "name": "ReferenceBlackWhite",
+    "description": "Reference black and white",
+    "long_description": "The ReferenceBlackWhite field contains two values for each of three primaries that specify headroom and footroom values for each of three primaries (channels).",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>, \"Section 20:  RGB Image Colorimetry\", p. 86",
+    "count": "6",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x022F",
+    "name": "StripRowCounts",
+    "description": "TIFF-FX rows per strips",
+    "long_description": "The StripRowCounts field contains a count for each strip of the number of rows in that strip for use with TIFF-FX MRC data, which can have a variable number of row per strip. If the StripRowCounts field is present then the RowsPerStrip field is to not be.",
+    "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "SPI",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x02BC",
+    "name": "XMLPacket",
+    "description": "XMP (XML) packet",
+    "long_description": "The XMLPacket field contains embedded XMP (XML/RDF) metadata about the information.",
+    "references": "<a href=\"#XMPEMBED\">XMPEMBED</a>",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "BLOB"
+    }
+  },
+  {
+    "tag": "0x03E7",
+    "name": "USPTOMiscellaneous",
+    "description": "USPTO Miscellaneous (private tag)",
+    "long_description": "The USPTO Miscellaenous field is by default blank.",
+    "references": "<a href=\"#YB2\">YB2</a>, p. 7",
+    "count": "253",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x800D",
+    "name": "ImageID",
+    "description": "OPI image identifier",
+    "long_description": "The ImageID tag contains a filename or other identifier of the high resolution original of this image.",
+    "references": "See also<a href=\"#OPIProxy\">OPIProxy</a>. <a href=\"#TIFFPM6\">TIFFPM6</a>, p. 15\n <a href=\"#OPI2\">OPI2</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x80A3",
+    "name": "WangTag1",
+    "description": "Wang Imaging (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x80A4",
+    "name": "WangAnnotation",
+    "description": "Wang Imaging annotation",
+    "long_description": "The WangAnnotation field contains the content of data structures that define annotations to the image per the Wang/Eastman/Kodak/eiStream annotation specification.",
+    "references": "<a href=\"#WANGANNO\">WANGANNO</a>",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "WANGANNOTATION"
+    }
+  },
+  {
+    "tag": "0x80A5",
+    "name": "WangTag3",
+    "description": "Wang Imaging (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x80A6",
+    "name": "WangTag4",
+    "description": "Wang Imaging (private tag)",
+    "long_description": "The WangTag field contains some information put into TIFF files by Wang Imaging software.",
+    "references": "",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x828D",
+    "name": "CFARepeatPatternDim",
+    "description": "TIFF/EP color filter array dimensions",
+    "long_description": "The CFARepeatPatternDim field contains two values representing the minimum rows and columns to define the repeating patterns of the color filter array.",
+    "references": "See also<a href=\"#CFAPattern\">CFAPattern</a>, <a href=\"#SensingMethod\">SensingMethod</a>. <a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "2",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x828E",
+    "name": "CFAPattern",
+    "description": "TIFF/EP picture color filter array pattern",
+    "long_description": "The CFAPattern field contains a description of the color filter array geometric pattern for interleaving of sampling channels.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "CFA",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "CFAPATTERN"
+    }
+  },
+  {
+    "tag": "0x828F",
+    "name": "BatteryLevel",
+    "description": "TIFF/EP battery level",
+    "long_description": "The BatteryLevel field contains a value of the battery level as a fraction or string.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\nN",
+    "dtype": ["RATIONAL", "ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8298",
+    "name": "Copyright",
+    "description": "Copyright notice",
+    "long_description": "The Copyright field contains copyright information of the interpreted image data. GEDI standard, gedistand99.pdf, page 39, has value being 0x0828.",
+    "references": "<a href=\"#TIFF6\">TIFF6</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x829A",
+    "name": "ExposureTime",
+    "description": "TIFF/EP picture exposure time",
+    "long_description": "The ExposureTime field contains how many seconds the frame was exposed.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x829D",
+    "name": "FNumber",
+    "description": "TIFF/EP picture F number",
+    "long_description": "The FNumber field contains the F number of the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x830E",
+    "name": "ModelPixelScaleTag",
+    "description": "GeoTIFF model pixel scale",
+    "long_description": "",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "3",
+    "dtype": ["DOUBLE"],
+    "interpretation": {
+      "kind": "GEOPIXELSCALE"
+    }
+  },
+  {
+    "tag": "0x8335",
+    "name": "AdventScale",
+    "description": "Advent Imaging scale (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8336",
+    "name": "AdventRevision",
+    "description": "Advent Imaging revision (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x83BB",
+    "name": "IPTCNAA",
+    "description": "IPTC/NAA metadata record",
+    "long_description": "The IPTCNAA field contains an IPTC/NAA record.",
+    "references": "<a href=\"#RICHTIFF\">RICHTIFF</a> \n <a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["BYTE", "ASCII", "LONG"],
+    "interpretation": {
+      "kind": "IPTCNAARECORD"
+    }
+  },
+  {
+    "tag": "0x847E",
+    "name": "INGRPacketData",
+    "description": "Intergraph INGR packet data (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "INGRPACKET"
+    }
+  },
+  {
+    "tag": "0x847F",
+    "name": "INGRFlagRegisters",
+    "description": "Intergraph INGR flag registers (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "INGRFLAGREGISTER"
+    }
+  },
+  {
+    "tag": "0x8480",
+    "name": "IntergraphMatrix",
+    "description": "Intergraph matrix (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "17\n16",
+    "dtype": ["DOUBLE"],
+    "interpretation": {
+      "kind": "INGRMATRIX"
+    }
+  },
+  {
+    "tag": "0x8481",
+    "name": "INGRReserved",
+    "description": "Intergraph reserved (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8482",
+    "name": "ModelTiepointTag",
+    "description": "GeoTIFF model tiepoints",
+    "long_description": "Also called Georeferencing.",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "N",
+    "dtype": ["DOUBLE"],
+    "interpretation": {
+      "kind": "GEOTIEPOINTS"
+    }
+  },
+  {
+    "tag": "0x84E0",
+    "name": "Site",
+    "description": "TIFF/IT production site",
+    "long_description": "The Site field contains the location of where the image was originated or converted to TIFF/IT.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84E1",
+    "name": "ColorSequence",
+    "description": "TIFF/IT color sequence",
+    "long_description": "The ColorSequence field is a string where each letter signifies a color to be assigned to a component.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "COLORSEQUENCE"
+    }
+  },
+  {
+    "tag": "0x84E2",
+    "name": "IT8Header",
+    "description": "TIFF/IT header",
+    "long_description": "The IT8Header field contains null-separated headers from ISO 10755, ISO 10756, and ISO 10759.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "MULTIPLEASCII"
+    }
+  },
+  {
+    "tag": "0x84E3",
+    "name": "RasterPadding",
+    "description": "TIFF/IT raster padding",
+    "long_description": "The RasterPadding field describes the padding of data to byte, word, long word, sector, or double sector. When applied to line interleaved data, the padding applies to each color instead of each line.",
+    "references": "See also<a href=\"#PhotometricInterpretation\">PhotometricInterpretation</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "ByteRaster": "0",
+        "WordRaster": "1",
+        "LongWordRaster": "2",
+        "SectorRaster": "9",
+        "LongSectorRaster": "10"
+      }
+    }
+  },
+  {
+    "tag": "0x84E4",
+    "name": "BitsPerRunLength",
+    "description": "TIFF/IT LW bits per run length",
+    "long_description": "The BitsPerRunLength field contains how many bits are required to represent the short run of the run length encoding of the TIFF/IT LW (line work) data.",
+    "references": "See also<a href=\"#BitsPerExtendedRunLength\">BitsPerExtendedRunLength</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84E5",
+    "name": "BitsPerExtendedRunLength",
+    "description": "TIFF/IT LW bits per extended run length",
+    "long_description": "The BitsPerRunLength field contains how many bits are required to represent the long run of the run length encoding of the TIFF/IT LW (line work) data.",
+    "references": "See also<a href=\"#BitsPerRunLength\">BitsPerRunLength</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84E6",
+    "name": "ColorTable",
+    "description": "TIFF/IT LW color table",
+    "long_description": "The ColorTable field contains a color identifier and transparency information for separated line work images.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>, p. 17",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84E7",
+    "name": "ImageColorIndicator",
+    "description": "TIFF/IT BP/BL foreground color indicator",
+    "long_description": "The ImageColorIndicator field describes whether the image or foreground color is in the binary image or the monochrome continuous tone image.",
+    "references": "See also<a href=\"#BackgroundColorIndicator\">BackgroundColorIndicator</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "UnspecifiedImageColor (Image color not specified)": "0",
+        "SpecifiedImageColor (Image color specified)": "1"
+      }
+    }
+  },
+  {
+    "tag": "0x84E8",
+    "name": "BackgroundColorIndicator",
+    "description": "TIFF/IT BP/BL background color indicator",
+    "long_description": "The BackgroundColorIndicator field describes whether the image or background color is in the binary image or the monochrome continuous tone image.",
+    "references": "See also<a href=\"#ImageColorIndicator\">ImageColorIndicator</a>. <a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "UnspecifiedBackgroundColor (Background color not specified)": "0",
+        "SpecifiedBackgroundColor (Background color specified)": "1"
+      }
+    }
+  },
+  {
+    "tag": "0x84E9",
+    "name": "ImageColorValue",
+    "description": "TIFF/IT BP/BL foreground color value",
+    "long_description": "The ImageColorValue describes the foreground color of a TIFF/IT BP or BL bitmap.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "CSC",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84EA",
+    "name": "BackgroundColorValue",
+    "description": "TIFF/IT BP/BL background color value",
+    "long_description": "The BackgroundColorValue describes the background color of a TIFF/IT BP or BL bitmap.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "CSC",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84EB",
+    "name": "PixelIntensityRange",
+    "description": "TIFF/IT MP pixel intensity range",
+    "long_description": "The PixelIntensityRange is similar to DotRange for a TIFF/IT MP image.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84EC",
+    "name": "TransparencyIndicator",
+    "description": "TIFF/IT HC transparency indicator",
+    "long_description": "The TransparencyIndicator field denotes whether transparency information is within TIFF/IT HC data.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84ED",
+    "name": "ColorCharacterization",
+    "description": "TIFF/IT color characterization",
+    "long_description": "The ColorCharacterization fields describes colors per ISO 12641, ISO 12642, and ANSI CGATS.15.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x84EE",
+    "name": "HCUsage",
+    "description": "TIFF/IT HC usage",
+    "long_description": "The HCUsage field defines the type of information in the TIFF/IT HC file.",
+    "references": "<a href=\"#TIFFIT\">TIFFIT</a>",
+    "count": "1",
+    "dtype": ["LONG", "SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {}
+    }
+  },
+  {
+    "tag": "0x8568",
+    "name": "KodakIPTC",
+    "description": "IPTC/NAA metadata record",
+    "long_description": "The KodakIPTC field contains an IPTC/NAA record.",
+    "references": "<a href=\"#RICHTIFF\">RICHTIFF</a>",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "IPTCNAARECORD"
+    }
+  },
+  {
+    "tag": "0x85B8",
+    "name": "PixelMagicJBIGOptions",
+    "description": "Pixel Magic JBIG options (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x85D8",
+    "name": "ModelTransformationTag",
+    "description": "GeoTIFF model transformation",
+    "long_description": "",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "16",
+    "dtype": ["DOUBLE"],
+    "interpretation": {
+      "kind": "GEOTRANSFORM"
+    }
+  },
+  {
+    "tag": "0x8649",
+    "name": "ImageResourceBlocks",
+    "description": "Adobe Photoshop image resource blocks",
+    "long_description": "The Photoshop field contains information embedded by the Adobe Photoshop application.",
+    "references": "<a href=\"#PSFF\">PSFF</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED", "BYTE"],
+    "interpretation": {
+      "kind": "PHOTOSHOP"
+    }
+  },
+  {
+    "tag": "0x8769",
+    "name": "ExifIFD",
+    "description": "Exif IFD offset",
+    "long_description": "The ExifIFD field contains an offset to a sub-IFD containing Exif (digital camera) information.",
+    "references": "<a href=\"#EXIF21\">EXIF21</a>, p. 19",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "IFDOFFSET",
+      "ifd_type": "EXIF"
+    }
+  },
+  {
+    "tag": "0x8773",
+    "name": "InterColorProfile",
+    "description": "ICC profile",
+    "long_description": "The InterColorProfile field contains an InterColor Consortium (ICC) format color space characterization/profile.",
+    "references": "<a href=\"#ICCEMBED\">ICCEMBED</a> \n <a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "ICCPROFILE"
+    }
+  },
+  {
+    "tag": "0x877F",
+    "name": "TIFF_FXExtensions",
+    "description": "TIFF-FX Extensions",
+    "long_description": "The TIFF-FXExtensions field describes extensions used.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "Resolution_ImageWidth (Extended resolutions and imagewidths extension)": "bit 0",
+        "N_Layer_ProfileM (N-Layer Profile M extension)": "bit 1",
+        "SharedData (Shared data extension)": "bit 2",
+        "BilevelJBIG2_ProfileT (Black-and-White JBIG2 coding extension)": "bit 3",
+        "JBIG2Extension_ProfileM (JBIG2 mask layer coding and foreground layer color tag extension)": "bit 4"
+      }
+    }
+  },
+  {
+    "tag": "0x8780",
+    "name": "MultiProfiles",
+    "description": "TIFF-FX multiple profiles",
+    "long_description": "The MultiProfiles field describes multiple profiles used.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>, <a href=\"#FaxProfile\">FaxProfile</a>, <a href=\"#TIFF-FXExtensions\">TIFF-FXExtensions</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {
+        "ProfileS": "bit 0",
+        "ProfileF": "bit 1",
+        "ProfileJ": "bit 2",
+        "ProfileC": "bit 3",
+        "ProfileL": "bit 4",
+        "ProfileM": "bit 5",
+        "ProfileT": "bit 6",
+        "Resolution_ImageWidth (Extended resolutions and imagewidths extension)": "bit 7",
+        "N_Layer_ProfileM (N-Layer Profile M extension)": "bit 8",
+        "SharedData (Shared data extension)": "bit 9",
+        "JBIG2Extension_ProfileM (JBIG2 mask layer coding and foreground layer color tag extension)": "bit 10"
+      }
+    }
+  },
+  {
+    "tag": "0x8781",
+    "name": "SharedData",
+    "description": "TIFF-FX shared data offset",
+    "long_description": "The SharedData field cotains an offset to the TIFF-FX Extension share data block within the file.",
+    "references": "See also<a href=\"#GlobalParametersIFD\">GlobalParametersIFD</a>. <a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8782",
+    "name": "T88Options",
+    "description": "TIFF-FX T.88 options",
+    "long_description": "The T88Options field contains options of the ITU-T T.88 (JBIG2) coding.",
+    "references": "<a href=\"#TIFFFXEX1\">TIFFFXEX1</a>",
+    "count": "1\n2",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "BITFLAGS",
+      "values": {}
+    }
+  },
+  {
+    "tag": "0x87AC",
+    "name": "ImageLayer",
+    "description": "TIFF-FX MRC image layer",
+    "long_description": "The ImageLayer field contains two values, one to describe of which of the three TIFF-FX MRC layers this image component is a part, the second is the order in that the image component is to be composited.",
+    "references": "<a href=\"#TIFFFX\">TIFFFX</a>",
+    "count": "2",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x87AF",
+    "name": "GeoKeyDirectoryTag",
+    "description": "GeoTIFF key directory",
+    "long_description": "Also called ProjectionInfoTag, CoordSystemInfoTag.",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "N",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "GEOKEYDIR"
+    }
+  },
+  {
+    "tag": "0x87B0",
+    "name": "GeoDoubleParamsTag",
+    "description": "GeoTIFF double parameters",
+    "long_description": "",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "N",
+    "dtype": ["DOUBLE"],
+    "interpretation": {
+      "kind": "GEOKEYDOUBLE"
+    }
+  },
+  {
+    "tag": "0x87B1",
+    "name": "GeoAsciiParamsTag",
+    "description": "GeoTIFF ASCII parameters",
+    "long_description": "",
+    "references": "<a href=\"#GEOTIFF\">GEOTIFF</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "GEOKEYASCII"
+    }
+  },
+  {
+    "tag": "0x8822",
+    "name": "ExposureProgram",
+    "description": "TIFF/EP picture exposure program",
+    "long_description": "The ExposureProgram field describes the exposure setting program condition of the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Undefined": "0",
+        "Manual": "1",
+        "NormalProgram": "2",
+        "AperturePriority": "3",
+        "ShutterPriority": "4",
+        "CreativeProgram": "5",
+        "ActionProgram": "6",
+        "PortraitMode": "7",
+        "LandscapeMode": "8"
+      }
+    }
+  },
+  {
+    "tag": "0x8824",
+    "name": "SpectralSensitivity",
+    "description": "TIFF/EP picture spectral sensitivity",
+    "long_description": "The SpectralSensitivity field contains a description of the sensitivity of each channel of the image data according to ASTM standards.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8825",
+    "name": "GPSInfoIFD",
+    "description": "Exif GPS offset",
+    "long_description": "The GPSInfoIFD field contains an offset to a sub-IFD containing GPS (Global Positioning System) information.",
+    "references": "<a href=\"#EXIF21\">EXIF21</a>, p. 19\n <a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "IFDOFFSET",
+      "ifd_type": "GPSINFO"
+    }
+  },
+  {
+    "tag": "0x8827",
+    "name": "ISOSpeedRatings",
+    "description": "TIFF/EP picture ISO speed ratings",
+    "long_description": "The ISOSpeedRatings field contains the ISO speed or ISO latitude of the camera as specified by ISO 12232.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8828",
+    "name": "OECF",
+    "description": "TIFF/EP picture optoelectronic conversion function",
+    "long_description": "The OECF field contains a specification of an opto-electronic conversion function as specified by ISO 14524.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x8829",
+    "name": "Interlace",
+    "description": "TIFF/EP field number",
+    "long_description": "The Interlace field contains a value that describes the vertical and horizontal field of multiple field TIFF/EP images.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x882A",
+    "name": "TimeZoneOffset",
+    "description": "TIFF/EP time zone offset",
+    "long_description": "The TimeZoneOffset contains the time zone offset in hours from GMT for the DateTimeOriginal field and optionally the DateTime field of the TIFF/EP image.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["SSHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x882B",
+    "name": "SelfTimerMode",
+    "description": "TIFF/EP self timer mode",
+    "long_description": "The SelfTimerMode field contains the number of seconds from when the plunger was depressed that the camera fired, or zero for no delay.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x885C",
+    "name": "FaxRecvParams",
+    "description": "SGI fax receival parameters (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x885D",
+    "name": "FaxSubAddress",
+    "description": "SGI fax subaddress (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x885E",
+    "name": "FaxRecvTime",
+    "description": "SGI fax receival time (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9003",
+    "name": "DateTimeOriginal",
+    "description": "TIFF/EP origination date/time",
+    "long_description": "The DateTimeOriginal field contains 20 ASCII characters in the form \"YYYY:MM:DD HH:MM:SS\" indicating the data and time when the image data was sampled.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "20",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DATETIME"
+    }
+  },
+  {
+    "tag": "0x9102",
+    "name": "CompressedBitsPerPixel",
+    "description": "TIFF/EP compressed bits per pixel",
+    "long_description": "The CompressedBitsPerPixel field contains TIFF/EP data compression information.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9201",
+    "name": "ShutterSpeedValue",
+    "description": "TIFF/EP shutter speed",
+    "long_description": "The ShutterSpeedValue contains the shutter speed in APEX units of the TIFF/EP image.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9202",
+    "name": "ApertureValue",
+    "description": "TIFF/EP picture lens aperture",
+    "long_description": "The ApertureValue field contains the APEX unit valued lens aperture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9203",
+    "name": "BrightnessValue",
+    "description": "TIFF/EP picture brightness",
+    "long_description": "The BrightnessValue field contains the APEX unit valued brightness.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9204",
+    "name": "ExposureBiasValue",
+    "description": "TIFF/EP picture exposure bias",
+    "long_description": "The ExposureBiasValue field contains the APEX unit valued exposure bias.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9205",
+    "name": "MaxApertureValue",
+    "description": "TIFF/EP picture lens maximum aperture",
+    "long_description": "The MaxApertureValue field contains the APEX unit valued minimum F number of the lens.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9206",
+    "name": "SubjectDistance",
+    "description": "TIFF/EP picture subject distance",
+    "long_description": "The SubjectDistance field contains the distance from the camera to the picture's subject, in meters.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9207",
+    "name": "MeteringMode",
+    "description": "TIFF/EP picture metering mode",
+    "long_description": "The MeteringMode field describes the metering mode of the camera.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unidentified": "0",
+        "Average": "1",
+        "CenterWeightedAverage": "2",
+        "Spot": "3",
+        "MultiSpot": "4"
+      }
+    }
+  },
+  {
+    "tag": "0x9208",
+    "name": "LightSource",
+    "description": "TIFF/EP picture light source",
+    "long_description": "The LightSource field describes the light source conditions of the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unidentified": "0",
+        "Daylight": "1",
+        "Fluorescent": "2",
+        "Tungsten": "3",
+        "Flash": "10",
+        "StandardIlluminantA": "17",
+        "StandardIlluminantB": "18",
+        "StandardIlluminantC": "19",
+        "D55Illuminant": "20",
+        "D65Illuminant": "21",
+        "D75Illuminant": "22"
+      }
+    }
+  },
+  {
+    "tag": "0x9209",
+    "name": "Flash",
+    "description": "TIFF/EP picture flash usage",
+    "long_description": "The Flash field describes the use of strobe flash with the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "FLASHEP"
+    }
+  },
+  {
+    "tag": "0x920A",
+    "name": "FocalLength",
+    "description": "TIFF/EP picture lens focal length",
+    "long_description": "The FocalLength field contains the focal length in millimeters of the lens.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x920B",
+    "name": "FlashEnergy",
+    "description": "TIFF/EP picture flash energy",
+    "long_description": "The FlashEnergy field contains the power of the strobe flash in BCPS, beam candlepower seconds, units.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x920C",
+    "name": "SpatialFrequencyResponse",
+    "description": "TIFF/EP picture spatial frequency response",
+    "long_description": "The SpatialFrequencyResponse field contains the device spatial frequency response table and values for the picture per ISO 12233.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x920D",
+    "name": "Noise",
+    "description": "TIFF/EP noise measurement",
+    "long_description": "The Noise field contains a measurement of the noise value of the TIFF/EP image.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x920E",
+    "name": "FocalPlaneXResolution",
+    "description": "TIFF/EP picture focal plane column resolution",
+    "long_description": "The FocalPlaneXResolution field contains the focal plane column resolution in FocalPlaneResolutionUnits units.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x920F",
+    "name": "FocalPlaneYResolution",
+    "description": "TIFF/EP picture focal plane row resolution",
+    "long_description": "The FocalPlaneXResolution field contains the focal plane row resolution in FocalPlaneResolutionUnit units.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9210",
+    "name": "FocalPlaneResolutionUnit",
+    "description": "TIFF/EP picture focal plane resolution unit",
+    "long_description": "The FocalPlaneResolutionUnit field describes the focal plane resolution unit.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Inch": "1",
+        "Meter": "2",
+        "Centimeter": "3",
+        "Millimeter": "4",
+        "Micrometer": "5"
+      }
+    }
+  },
+  {
+    "tag": "0x9211",
+    "name": "ImageNumber",
+    "description": "TIFF/EP image number",
+    "long_description": "The ImageNumber fields contains an identifier assigned to an image in a TIFF/EP file.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9212",
+    "name": "SecurityClassification",
+    "description": "TIFF/EP security classification",
+    "long_description": "The SecurityClassification field contains either a single ASCII character or an ASCII string describing the security classification of the image per the NITF specification (MIL-STD-2500).",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\nN",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "CHARACTERORASCII"
+    }
+  },
+  {
+    "tag": "0x9213",
+    "name": "ImageHistory",
+    "description": "TIFF/EP image modification history",
+    "long_description": "The ImageHistory field contains a description of modifications to the TIFF/EP image.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9214",
+    "name": "SubjectLocation",
+    "description": "TIFF/EP picture subject location",
+    "long_description": "The SubjectLocation field contains two coordinate values into the image of the pixel of the subject location in the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "2\n3\n4",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9215",
+    "name": "ExposureIndex",
+    "description": "TIFF/EP picture exposure index",
+    "long_description": "The ExposureIndex field contains the camera exposure index setting.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1\n2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x9216",
+    "name": "TIFFEPStandardID",
+    "description": "TIFF/EP standard identifier",
+    "long_description": "The TIFFEPStandardID field contains four ASCII characters representing the TIFF/EP standard version of a TIFF/EP file, eg '1', '0', '0', '0'.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "4",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "FOURBYTEASCII"
+    }
+  },
+  {
+    "tag": "0x9217",
+    "name": "SensingMethod",
+    "description": "TIFF/EP picture sensing method",
+    "long_description": "The SensingMethod field describes the sensors that capture the image of the picture.",
+    "references": "<a href=\"#TIFFEP\">TIFFEP</a>",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Undefined": "0",
+        "MonochromeArea": "1",
+        "OneChipColorArea": "2",
+        "TwoChipColorArea": "3",
+        "ThreeChipColorArea": "4",
+        "ColorSequentialArea": "5",
+        "MonochromeLinearArea": "6",
+        "TriLinear": "7",
+        "ColorSequentialLinear": "8"
+      }
+    }
+  },
+  {
+    "tag": "0x923A",
+    "name": "CIP3DataFile",
+    "description": "CIP3 PPF data",
+    "long_description": "The CIP3DataFile field contains a string that is to be intepreted as the filename of a CIP3 PPF file, as a field of a TIFF/IT FP IFD.",
+    "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x923B",
+    "name": "CIP3Sheet",
+    "description": "CIP3 sheet name",
+    "long_description": "The CIP3Sheet field contains a string that references the sheet to use in a multiple sheet PPF file, as a field of a TIFF/IT FP IFD.",
+    "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x923C",
+    "name": "CIP3Side",
+    "description": "CIP3 sheet side",
+    "long_description": "The CIP3Side field describes which side of a PPF sheet is to be used, as a field of a TIFF/IT FP IFD.",
+    "references": "<a href=\"#CIP3EMBED\">CIP3EMBED</a>",
+    "count": "1",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0x935C",
+    "name": "ImageSourceData",
+    "description": "Adobe Photoshop image source data",
+    "long_description": "The ImageSourceData field contains information embedded by the Adobe Photoshop application.",
+    "references": "<a href=\"#TIFFPS\">TIFFPS</a>",
+    "count": "N",
+    "dtype": ["UNDEFINED"],
+    "interpretation": {
+      "kind": "PHOTOSHOP"
+    }
+  },
+  {
+    "tag": "0xA480",
+    "name": "GDAL_METADATA",
+    "description": "GDAL metadata (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "XML"
+    }
+  },
+  {
+    "tag": "0xA481",
+    "name": "GDAL_NODATA",
+    "description": "GDAL background/nodata (private tag)",
+    "long_description": "",
+    "references": "",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC580",
+    "name": "USPTOOriginalContentType",
+    "description": "USPTO Original Content Type (private tag)",
+    "long_description": "The USPTO OriginalContentType field describes the original content type of the image.",
+    "references": "<a href=\"#YB2\">YB2</a>, p. 7",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "TextOrDrawing (Text or black and white drawing (default))": "0",
+        "Grayscale (Grayscale drawing or photograph)": "1",
+        "Color (Color drawing or photograph)": "2"
+      }
+    }
+  },
+  {
+    "tag": "0xC612",
+    "name": "DNGVersion",
+    "description": "DNG version",
+    "long_description": "The DNGVersion contains four bytes containing the numeric value of the file's conformance version level to the DNG (Digital Negative) specification.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 15",
+    "count": "4",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "FOURBYTEDIGITS"
+    }
+  },
+  {
+    "tag": "0xC613",
+    "name": "DNGBackwardVersion",
+    "description": "DNG backwards compatible version",
+    "long_description": "The DNGBackwardsVersion field contains four bytes containing the numeric value of the file's conformance version level to a DNG (Digital Negative) specification.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 15",
+    "count": "4",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "FOURBYTEDIGITS"
+    }
+  },
+  {
+    "tag": "0xC614",
+    "name": "UniqueCameraModel",
+    "description": "DNG unique camera model",
+    "long_description": "The UniqueCameraModel field contains a null-terminated ASCII string noting the camera model.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 16",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC615",
+    "name": "LocalizedCameraModel",
+    "description": "DNG localized camera model",
+    "long_description": "The LocalizedCameraModel field contains a null-terminated ASCII string or a Unicode string noting the camera model.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 17",
+    "count": "N",
+    "dtype": ["ASCII", "BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC616",
+    "name": "CFAPlaneColor",
+    "description": "DNG CFA plane color",
+    "long_description": "The CFAPlaneColor fields contains a list of zero-based digits indicating the order of the color planes of the color filter array pattern for the LinearRaw photometric interpretation.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 17",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC617",
+    "name": "CFALayout",
+    "description": "DNG CFA spatial layout",
+    "long_description": "The CFALayout field denotes the spatial layout of the color filter array.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 18",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Rectangular": "1",
+        "Staggered_A": "2",
+        "Staggered_B": "3",
+        "Staggered_C": "4",
+        "Staggered_D": "5"
+      }
+    }
+  },
+  {
+    "tag": "0xC618",
+    "name": "LinearizationTable",
+    "description": "DNG linearization table",
+    "long_description": "The LinearizationTable field contains a lookup table (LUT) that maps data values of the samples of the image to non-linear values.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 18",
+    "count": "N",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC619",
+    "name": "BlackLevelRepeatDim",
+    "description": "DNG black level repeat dimensions",
+    "long_description": "The BlackLevelRepeatDim field contains two values, one each for rows and columns of the black level tag.",
+    "references": "See also<a href=\"#BlackLevel\">BlackLevel</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 19",
+    "count": "2",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61A",
+    "name": "BlackLevel",
+    "description": "DNG black level",
+    "long_description": "The BlackLevel field contains the \"zero light\" or thermal black encoding level, as a repeating pattern. The values are stored in row-column-sample scan order.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 19",
+    "count": "N",
+    "dtype": ["SHORT", "LONG", "RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61B",
+    "name": "BlackLevelDeltaH",
+    "description": "DNG black level delta - horizontal",
+    "long_description": "The BlackLevelDeltaH field encodes the per-column difference of the \"zero light\" level.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 20",
+    "count": "N\nWidth",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61C",
+    "name": "BlackLevelDeltaV",
+    "description": "DNG black level delta - vertical",
+    "long_description": "The BlackLevelDeltaV field encodes the per-row difference of the \"zero light\" level.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 20",
+    "count": "Length",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61D",
+    "name": "WhiteLevel",
+    "description": "DNG white level",
+    "long_description": "The WhiteLevel field contains the fully-saturated encoding level for the raw samples, per sample.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 21",
+    "count": "SPP",
+    "dtype": ["SHORT", "LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61E",
+    "name": "DefaultScale",
+    "description": "DNG default scale",
+    "long_description": "The DefaultScale field contains a pair of scale factors for cameras with non-square pixels.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 21",
+    "count": "2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC61F",
+    "name": "DefaultCropOrigin",
+    "description": "DNG default crop origin",
+    "long_description": "The DefaultCropOrigin field contains a pair of coordinates the mark the origin, in raw image coordinates.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 22",
+    "count": "2",
+    "dtype": ["SHORT", "LONG", "RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC620",
+    "name": "DefaultCropSize",
+    "description": "DNG default crop size",
+    "long_description": "The DefaultCropSize field contains a pair of coordinates that mark the extent, in raw image coordinates.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 23",
+    "count": "2",
+    "dtype": ["SHORT", "LONG", "RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC621",
+    "name": "ColorMatrix1",
+    "description": "DNG color matrix, set one",
+    "long_description": "The ColorMatrix1 field contains a transformation matrix to convert CIE XYZ values to reference camera native color space values, under the illuminant specified as CalibrationIlluminant1. The matrix values are stored in row scan order.",
+    "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 24",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC622",
+    "name": "ColorMatrix2",
+    "description": "DNG color matrix, set two",
+    "long_description": "The ColorMatrix2 field contains a transformation matrix to convert CIE XYZ values to reference camera native color space values, under the illuminant specified as CalibrationIlluminant2. The matrix values are stored in row scan order.",
+    "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 25",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC623",
+    "name": "CameraCalibration1",
+    "description": "DNG camera calibration, set one",
+    "long_description": "The CameraCalibration1 field contains a transformation matrix to convert reference camera native color space values to individual camera native color space samples, under the illuminant specified as CalibrationIlluminant1. The matrix is stored in row scan order.",
+    "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 25",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC624",
+    "name": "CameraCalibration2",
+    "description": "DNG camera calibration, set two",
+    "long_description": "The CameraCalibration2 field contains a transformation matrix to convert reference camera native color space values to individual camera native color space samples, under the illuminant specified as CalibrationIlluminant2. The matrix is stored in row scan order.",
+    "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 26",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC625",
+    "name": "ReductionMatrix1",
+    "description": "DNG reduction matrix, set one",
+    "long_description": "The ReductionMatrix1 contains a dimensionality reduction matrix for use as the first stage of converting camera native color space values to CIE XYZ, under the illuminant specified as CalibrationIlluminant1.",
+    "references": "See also<a href=\"#CalibrationIlluminant1\">CalibrationIlluminant1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 27",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC626",
+    "name": "ReductionMatrix2",
+    "description": "DNG reduction matrix, set two",
+    "long_description": "The ReductionMatrix2 contains a dimensionality reduction matrix for use as the first stage of converting camera native color space values to CIE XYZ, under the illuminant specified as CalibrationIlluminant2.",
+    "references": "See also<a href=\"#CalibrationIlluminant2\">CalibrationIlluminant2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 27",
+    "count": "N",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC627",
+    "name": "AnalogBalance",
+    "description": "DNG analog balance",
+    "long_description": "The AnalogBalance field contains the gain values applied to white balance.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 28",
+    "count": "N",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC628",
+    "name": "AsShotNeutral",
+    "description": "DNG neutral white balance value",
+    "long_description": "The AsShotNeutral fields contains the neutral white balance color in linear reference color space values.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 28",
+    "count": "N",
+    "dtype": ["SHORT", "RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC629",
+    "name": "AsShotWhiteXY",
+    "description": "DNG selected white balance",
+    "long_description": "The AsShotWhiteXY field contains xy chromaticity coordinates of the white balance.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 29",
+    "count": "2",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62A",
+    "name": "BaselineExposure",
+    "description": "DNG baseline exposure",
+    "long_description": "The BaselineExposure field contains the zero point for footroom, in EV units.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 29",
+    "count": "1",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62B",
+    "name": "BaselineNoise",
+    "description": "DNG baseline noise",
+    "long_description": "The BaselineNoise fields contains the relative noise of a camera at ISO 100 compared to the noise of a reference camera model.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 30",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62C",
+    "name": "BaselineSharpness",
+    "description": "DNG baseline sharpness",
+    "long_description": "The BaselineSharpness field contains the relative sharpening required for the camera model, compared to that of a reference camera model.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 30",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62D",
+    "name": "BayerGreenSplit",
+    "description": "DNG Bayer green split",
+    "long_description": "The BayerGreenSplit field contains a value in arbitrary units relating the tracking of the green pixels of the blue/green rows to those in red/green rows, only in color filter arrays using a Bayer pattern filter array.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 31",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62E",
+    "name": "LinearResponseLimit",
+    "description": "DNG linear response limit",
+    "long_description": "The LinearResponseLimit field specifies the range of linear sensor response.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 31",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC62F",
+    "name": "CameraSerialNumber",
+    "description": "DNG camera serial number",
+    "long_description": "The CameraSerialNumber contains the serial number of the camera or camera body.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 32",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC630",
+    "name": "LensInfo",
+    "description": "DNG lens information",
+    "long_description": "The LensInfo field contains values describing the focal length and F-stop of the lens used. The first and second values specify minimum and maximum focal length in millimeters, the third and fourth values specify minimum and maximum F-stop at minimum and maximum focal length and maximum and minimum aperture.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 32",
+    "count": "4",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC631",
+    "name": "ChromaBlurRadius",
+    "description": "DNG chroma blur radius",
+    "long_description": "The ChromaBlurRadius field contains a value specifying the chroma blur area.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 33",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC632",
+    "name": "AntiAliasStrength",
+    "description": "DNG anti-alias strength",
+    "long_description": "The AntiAliasStrength field denotes the relative strength of the camera's anti-alias filter, from 0.0 (no anti-aliasing filter) to 1.0 (effective anti-alias filter).",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 33",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC634",
+    "name": "DNGPrivateData",
+    "description": "DNG private data field",
+    "long_description": "The DNGPrivateData field contains private data.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 34",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "BLOB"
+    }
+  },
+  {
+    "tag": "0xC635",
+    "name": "MakerNoteSafety",
+    "description": "DNG makernote safety",
+    "long_description": "The MakerNoteSafety field denotes whether it is safe to copy the meaningful contents of the MakerNote in editing the file.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 35",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unsafe": "0",
+        "Safe": "1"
+      }
+    }
+  },
+  {
+    "tag": "0xC65A",
+    "name": "CalibrationIlluminant1",
+    "description": "DNG calibration illuminant, set one",
+    "long_description": "The CalibrationIlluminantField1 field denotes the light source for the first calibration set.",
+    "references": "See also<a href=\"#LightSource\">LightSource</a>, <a href=\"#ColorMatrix1\">ColorMatrix1</a>, <a href=\"#CameraCalibration1\">CameraCalibration1</a>, <a href=\"#ReductionMatrix1\">ReductionMatrix1</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 23",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unidentified": "0",
+        "Daylight": "1",
+        "Fluorescent": "2",
+        "Tungsten": "3",
+        "Flash": "4",
+        "FineWeather": "9",
+        "CloudyWeather": "10",
+        "Shady": "11",
+        "DaylightFluorescent": "12",
+        "DayWhiteFluorescent": "13",
+        "CoolWhiteFluorescent": "14",
+        "WhiteFluorescent": "15",
+        "StandardIlluminantA": "17",
+        "StandardIlluminantB": "18",
+        "StandardIlluminantC": "19",
+        "D55Illuminant": "20",
+        "D65Illuminant": "21",
+        "D75Illuminant": "22",
+        "D50Illuminant": "23",
+        "ISOStudioTungsten": "24",
+        "Other": "255"
+      }
+    }
+  },
+  {
+    "tag": "0xC65B",
+    "name": "CalibrationIlluminant2",
+    "description": "DNG calibration illuminant, set two",
+    "long_description": "The CalibrationIlluminantField1 field denotes the light source for the second calibration set.",
+    "references": "See also<a href=\"#LightSource\">LightSource</a>, <a href=\"#ColorMatrix2\">ColorMatrix2</a>, <a href=\"#CameraCalibration2\">CameraCalibration2</a>, <a href=\"#ReductionMatrix2\">ReductionMatrix2</a>. <a href=\"#DNG1000\">DNG1000</a>, p. 24",
+    "count": "1",
+    "dtype": ["SHORT"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "Unidentified": "0",
+        "Daylight": "1",
+        "Fluorescent": "2",
+        "Tungsten": "3",
+        "Flash": "4",
+        "FineWeather": "9",
+        "CloudyWeather": "10",
+        "Shady": "11",
+        "DaylightFluorescent": "12",
+        "DayWhiteFluorescent": "13",
+        "CoolWhiteFluorescent": "14",
+        "WhiteFluorescent": "15",
+        "StandardIlluminantA": "17",
+        "StandardIlluminantB": "18",
+        "StandardIlluminantC": "19",
+        "D55Illuminant": "20",
+        "D65Illuminant": "21",
+        "D75Illuminant": "22",
+        "D50Illuminant": "23",
+        "ISOStudioTungsten": "24",
+        "Other": "255"
+      }
+    }
+  },
+  {
+    "tag": "0xC65C",
+    "name": "BestQualityScale",
+    "description": "DNG best-quality scale factor",
+    "long_description": "The BestQualityScale field contains a value to scale the default scale factors for improved quality.",
+    "references": "<a href=\"#DNG1000\">DNG1000</a>, p. 22",
+    "count": "1",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC660",
+    "name": "AliasLayerMetadata",
+    "description": "Alias/Wavefront layer metadata (private tag)",
+    "long_description": "The AliasLayerMetadata field contains information per the Alias Systems Multi-Layer TIFF specification.",
+    "references": "See also<a href=\"#Software\">Software</a>, <a href=\"#HostComputer\">HostComputer</a>, <a href=\"#PageName\">PageName</a>, <a href=\"#XPosition\">XPosition</a>, <a href=\"#YPosition\">YPosition</a>.",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC763",
+    "name": "TimeCodes",
+    "description": "Time Codes of the Image",
+    "long_description": "The optional TimeCodes tag shall contain an ordered array of time codes. All time codes shall be 8 bytes long and in binary format. The tag may contain from 1 to 10 time codes. When the tag contains more than one time code, the first one shall be the default time code. This specification does not prescribe how to use multiple time codes.\nEach time code shall be as defined for the 8-byte time code structure in SMPTE 331M-2004, Section 8.3. See also SMPTE 12-1-2008 and SMPTE 309-1999.",
+    "references": "CinemaDNG specification 1.1.0 p10",
+    "count": "N",
+    "dtype": ["BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC764",
+    "name": "FrameRate",
+    "description": "video frame rate in number of image frames per second",
+    "long_description": "The optional FrameRate tag shall specify the video frame rate in number of image frames per second, expressed as a signed rational number. The numerator shall be non-negative and the denominator shall be positive. This field value is identical to the sample rate field in SMPTE 377-1-2009.",
+    "references": "CinemaDNG specification 1.1.0 p11",
+    "count": "1",
+    "dtype": ["SRATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC772",
+    "name": "TStop",
+    "description": "T-stop of the actual lens",
+    "long_description": "The optional TStop tag shall specify the T-stop of the actual lens, expressed as an unsigned rational number. T-stop is also known as T-number or the photometric aperture of the lens. (F-number is the geometric aperture of the lens.) When the exact value is known, the T-stop shall be specified using a single number. Alternately, two numbers shall be used to indicate a T-stop range, in which case the first number shall be the minimum T-stop and the second number shall be the maximum T-stop.",
+    "references": "CinemaDNG specification 1.1.0 p11",
+    "count": "N",
+    "dtype": ["RATIONAL"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC789",
+    "name": "ReelName",
+    "description": "name for a sequence of images",
+    "long_description": "The optional ReelName tag shall specify a name for a sequence of images, where each image in the sequence has a unique image identifier (including but not limited to file name, frame number, date time, time code).",
+    "references": "CinemaDNG specification 1.1.0 p11",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC7A1",
+    "name": "CameraLabel",
+    "description": "a text label for how the camera is used or assigned in this clip",
+    "long_description": "The optional CameraLabel tag shall specify a text label for how the camera is used or assigned in this clip. This tag is similar to CameraLabel in XMP.",
+    "references": "CinemaDNG specification 1.1.0 p12",
+    "count": "N",
+    "dtype": ["ASCII"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC6F8",
+    "name": "ProfileName",
+    "description": "name of the camera profile",
+    "long_description": "A UTF-8 encoded string containing the name of the camera profile. This tag is optional if there is only a single camera profile stored in the file but is required for all camera profiles if there is more than one camera profile stored in the file.",
+    "references": "DNG specification 1.4.0 p53",
+    "count": "N",
+    "dtype": ["ASCII", "BYTE"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC6FC",
+    "name": "ProfileToneCurve",
+    "description": "tone curve that can be applied while processing the image as a starting point for user adjustments",
+    "long_description": "This tag contains a default tone curve that can be applied while processing the image as a starting point for user adjustments. The curve is specified as a list of 32-bit IEEE floating- point value pairs in linear gamma. Each sample has an input value in the range of 0.0 to 1.0, and an output value in the range of 0.0 to 1.0. The first sample is required to be (0.0, 0.0), and the last sample is required to be (1.0, 1.0). Interpolated the curve using a cubic spline.",
+    "references": "DNG specification 1.4.0 p56",
+    "count": "N",
+    "dtype": ["FLOAT"],
+    "interpretation": {
+      "kind": "DEFAULT"
+    }
+  },
+  {
+    "tag": "0xC6FD",
+    "name": "ProfileEmbedPolicy",
+    "description": "usage rules for the associated camera profile",
+    "long_description": "\nThis tag contains information about the usage rules for the associated camera profile. The valid values and meanings are:\n• 0 = “allow copying”. The camera profile can be used to process, or be embedded in, any DNG file. It can be copied from DNG files to other DNG files, or copied from DNG files and stored on the user’s system for use in processing or embedding in any DNG file. The camera profile may not be used to process non-DNG files.\n• 1 = “embed if used”. This value applies the same rules as “allow copying”, except it does not allow copying the camera profile from a DNG file for use in processing any image other than the image in which it is embedded, unless the profile is already stored on the user’s system.\n• 2 = “embed never”. This value only applies to profiles stored on a user’s system but not already embedded in DNG files. These stored profiles can be used to process images but cannot be embedded in files. If a camera profile is already embedded in a DNG file, then this value has the same restrictions as “embed if used”.\n• 3 = “no restrictions”. The camera profile creator has not placed any restrictions on the use of the camera profile.",
+    "references": "DNG specification 1.4.0 p57",
+    "count": "1",
+    "dtype": ["LONG"],
+    "interpretation": {
+      "kind": "ENUMERATED",
+      "values": {
+        "allow copying": "0",
+        "embed if used": "1",
+        "embed never": "2",
+        "no restrictions": "3"
+      }
+    }
+  }
 ]

--- a/src/tags/mod.rs
+++ b/src/tags/mod.rs
@@ -2,21 +2,31 @@ use std::fmt::{Debug, Display, Formatter};
 
 include!(concat!(env!("OUT_DIR"), "/ifd_data.rs"));
 
-/// An enum indicating the context (and thus valid tags) of an IFD (normal / EXIF / GPSInfo)
+/// An enum indicating the context (and thus valid tags) of an IFD (normal/EXIF/GPSInfo).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IfdType {
     Ifd,
     Exif,
     GpsInfo,
 }
+
 impl IfdType {
-    pub fn get_namespace(&self) -> &[IfdFieldDescriptor] {
+    pub fn namespace(&self) -> &[IfdFieldDescriptor] {
         match self {
             IfdType::Ifd => &ifd::ALL,
             IfdType::Exif => &exif::ALL,
             IfdType::GpsInfo => &gps_info::ALL,
         }
     }
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use namespace() instead"
+    )]
+    pub fn get_namespace(&self) -> &[IfdFieldDescriptor] {
+        self.namespace()
+    }
+
     pub fn combined_namespace() -> impl Iterator<Item = &'static IfdFieldDescriptor> {
         ifd::ALL
             .iter()
@@ -24,13 +34,15 @@ impl IfdType {
             .chain(gps_info::ALL.iter())
     }
 }
+
 impl Default for IfdType {
     fn default() -> Self {
         Self::Ifd
     }
 }
 
-/// A data structure describing one specific Field (2byte key) that can appear in an IFD
+/// A data structure describing one specific Field (2byte key) that can appear in an IFD.
+///
 /// Possible keys are defined in various specs, such ass the TIFF, TIFF-EP, DNG, ... spec.
 #[derive(Debug, Copy, Clone, Eq)]
 pub struct IfdFieldDescriptor {
@@ -43,30 +55,33 @@ pub struct IfdFieldDescriptor {
     pub long_description: &'static str,
     pub references: &'static str,
 }
+
 impl IfdFieldDescriptor {
     pub fn as_maybe(&self) -> MaybeKnownIfdFieldDescriptor {
         MaybeKnownIfdFieldDescriptor::Known(*self)
     }
 }
+
 impl PartialEq for IfdFieldDescriptor {
     fn eq(&self, other: &Self) -> bool {
         self.tag == other.tag
     }
 }
+
 impl From<IfdFieldDescriptor> for MaybeKnownIfdFieldDescriptor {
     fn from(x: IfdFieldDescriptor) -> Self {
         MaybeKnownIfdFieldDescriptor::Known(x)
     }
 }
 
-/// An enum describing the amount of values we expect for a given Field
+/// An enum describing the amount of values we expect for a given Field.
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum IfdCount {
     N,
     ConcreteValue(u32),
 }
 
-/// The high level interpretation of a field. (i.e. Enum variants, Bitfields, IFD-pointer, ...)
+/// The high level interpretation of a field. (i.e. Enum variants, Bitfields, IFD-pointer, ...).
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum IfdTypeInterpretation {
     Default,
@@ -103,22 +118,25 @@ pub enum MaybeKnownIfdFieldDescriptor {
     Known(IfdFieldDescriptor),
     Unknown(u16),
 }
+
 impl MaybeKnownIfdFieldDescriptor {
     pub fn from_number(tag: u16, ifd_kind: IfdType) -> Self {
-        if let Some(description) = ifd_kind.get_namespace().iter().find(|x| x.tag == tag) {
+        if let Some(description) = ifd_kind.namespace().iter().find(|x| x.tag == tag) {
             Self::Known(*description)
         } else {
             Self::Unknown(tag)
         }
     }
+
     pub fn from_name(name: &str, ifd_kind: IfdType) -> Result<Self, String> {
-        if let Some(description) = ifd_kind.get_namespace().iter().find(|x| x.name == name) {
+        if let Some(description) = ifd_kind.namespace().iter().find(|x| x.name == name) {
             Ok(Self::Known(*description))
         } else {
             Err(format!("No Tag named '{}' known", name))
         }
     }
-    pub fn get_type_interpretation(&self) -> Option<&IfdTypeInterpretation> {
+
+    pub fn type_interpretation(&self) -> Option<&IfdTypeInterpretation> {
         match self {
             MaybeKnownIfdFieldDescriptor::Known(IfdFieldDescriptor { interpretation, .. }) => {
                 Some(interpretation)
@@ -126,25 +144,63 @@ impl MaybeKnownIfdFieldDescriptor {
             _ => None,
         }
     }
-    pub fn get_known_value_type(&self) -> Option<&[IfdValueType]> {
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `type_interpretation()` instead"
+    )]
+    pub fn get_type_interpretation(&self) -> Option<&IfdTypeInterpretation> {
+        self.type_interpretation()
+    }
+
+    pub fn known_value_type(&self) -> Option<&[IfdValueType]> {
         match self {
             MaybeKnownIfdFieldDescriptor::Known(known) => Some(known.dtype),
             MaybeKnownIfdFieldDescriptor::Unknown(_) => None,
         }
     }
-    pub fn get_known_name(&self) -> Option<&str> {
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `known_value_type()` instead"
+    )]
+    pub fn get_known_value_type(&self) -> Option<&[IfdValueType]> {
+        self.known_value_type()
+    }
+
+    pub fn known_name(&self) -> Option<&str> {
         match self {
             Self::Known(descriptor) => Some(descriptor.name),
             Self::Unknown(_) => None,
         }
     }
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "`get_` prefixes are non-canonical Rust; use `known_name()` instead"
+    )]
+    pub fn get_known_name(&self) -> Option<&str> {
+        self.known_name()
+    }
+
+    #[deprecated(
+        since = "1.6.0",
+        note = "Use `u16::From<MaybeKnownIfdFieldDescriptor>` instead"
+    )]
     pub fn numeric(&self) -> u16 {
-        match self {
+        (*self).into()
+    }
+}
+
+impl From<MaybeKnownIfdFieldDescriptor> for u16 {
+    fn from(value: MaybeKnownIfdFieldDescriptor) -> Self {
+        match value {
             MaybeKnownIfdFieldDescriptor::Known(descriptor) => descriptor.tag,
-            MaybeKnownIfdFieldDescriptor::Unknown(tag) => *tag,
+            MaybeKnownIfdFieldDescriptor::Unknown(tag) => tag,
         }
     }
 }
+
 impl Display for MaybeKnownIfdFieldDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self {
@@ -155,19 +211,22 @@ impl Display for MaybeKnownIfdFieldDescriptor {
         }
     }
 }
+
 impl Debug for MaybeKnownIfdFieldDescriptor {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self) // call method from Display
     }
 }
+
 impl PartialEq for MaybeKnownIfdFieldDescriptor {
     fn eq(&self, other: &Self) -> bool {
-        self.numeric() == other.numeric()
+        u16::from(*self) == (*other).into()
     }
 }
 
-/// The data-type of an IFD value
-/// This does not include the fact that it is possible to have a list of every type
+/// The data-type of an IFD value.
+///
+/// This does not include the fact that it is possible to have a list of every type.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum IfdValueType {
     Byte,
@@ -175,15 +234,58 @@ pub enum IfdValueType {
     Short,
     Long,
     Rational,
-    SByte,
+    SignedByte,
     Undefined,
-    SShort,
-    SLong,
-    SRational,
+    SignedShort,
+    SignedLong,
+    SignedRational,
     Float,
     Double,
 }
+
+impl TryFrom<u16> for IfdValueType {
+    type Error = String;
+
+    fn try_from(value: u16) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Byte),
+            2 => Ok(Self::Ascii),
+            3 => Ok(Self::Short),
+            4 => Ok(Self::Long),
+            5 => Ok(Self::Rational),
+            6 => Ok(Self::SignedByte),
+            7 => Ok(Self::Undefined),
+            8 => Ok(Self::SignedShort),
+            9 => Ok(Self::SignedLong),
+            10 => Ok(Self::SignedRational),
+            11 => Ok(Self::Float),
+            12 => Ok(Self::Double),
+            _ => Err(format!("Unknown value type: {}", value)),
+        }
+    }
+}
+
+impl From<IfdValueType> for u16 {
+    fn from(value: IfdValueType) -> Self {
+        match value {
+            IfdValueType::Byte => 1,
+            IfdValueType::Ascii => 2,
+            IfdValueType::Short => 3,
+            IfdValueType::Long => 4,
+            IfdValueType::Rational => 5,
+            IfdValueType::SignedByte => 6,
+            IfdValueType::Undefined => 7,
+            IfdValueType::SignedShort => 8,
+            IfdValueType::SignedLong => 9,
+            IfdValueType::SignedRational => 10,
+            IfdValueType::Float => 11,
+            IfdValueType::Double => 12,
+        }
+    }
+}
+
 impl IfdValueType {
+    #[deprecated(since = "1.6.0", note = "Use `IfdValueType::TryFrom<u16>` instead")]
     pub fn from_u16(n: u16) -> Option<Self> {
         match n {
             1 => Some(Self::Byte),
@@ -191,16 +293,18 @@ impl IfdValueType {
             3 => Some(Self::Short),
             4 => Some(Self::Long),
             5 => Some(Self::Rational),
-            6 => Some(Self::SByte),
+            6 => Some(Self::SignedByte),
             7 => Some(Self::Undefined),
-            8 => Some(Self::SShort),
-            9 => Some(Self::SLong),
-            10 => Some(Self::SRational),
+            8 => Some(Self::SignedShort),
+            9 => Some(Self::SignedLong),
+            10 => Some(Self::SignedRational),
             11 => Some(Self::Float),
             12 => Some(Self::Double),
             _ => None,
         }
     }
+
+    #[deprecated(since = "1.6.0", note = "Use `u16::From<IfdValueType>` instead")]
     pub fn as_u16(&self) -> u16 {
         match self {
             Self::Byte => 1,
@@ -208,29 +312,35 @@ impl IfdValueType {
             Self::Short => 3,
             Self::Long => 4,
             Self::Rational => 5,
-            Self::SByte => 6,
+            Self::SignedByte => 6,
             Self::Undefined => 7,
-            Self::SShort => 8,
-            Self::SLong => 9,
-            Self::SRational => 10,
+            Self::SignedShort => 8,
+            Self::SignedLong => 9,
+            Self::SignedRational => 10,
             Self::Float => 11,
             Self::Double => 12,
         }
     }
-    pub fn needed_bytes(&self) -> u32 {
+
+    pub fn size(&self) -> usize {
         match self {
             IfdValueType::Byte => 1,
             IfdValueType::Ascii => 1,
             IfdValueType::Short => 2,
             IfdValueType::Long => 4,
             IfdValueType::Rational => 8,
-            IfdValueType::SByte => 1,
+            IfdValueType::SignedByte => 1,
             IfdValueType::Undefined => 1,
-            IfdValueType::SShort => 2,
-            IfdValueType::SLong => 4,
-            IfdValueType::SRational => 8,
+            IfdValueType::SignedShort => 2,
+            IfdValueType::SignedLong => 4,
+            IfdValueType::SignedRational => 8,
             IfdValueType::Float => 4,
             IfdValueType::Double => 8,
         }
+    }
+
+    #[deprecated(since = "1.6.0", note = "Use `size()` instead")]
+    pub fn needed_bytes(&self) -> u32 {
+        self.size() as _
     }
 }

--- a/src/yaml/dumper.rs
+++ b/src/yaml/dumper.rs
@@ -19,14 +19,14 @@ impl IfdYamlDumper {
                 format!(
                     "{}: {}{}\n",
                     entry.tag,
-                    self.dump_tag_if_needed(entry.get_ref(&path.chain_tag(entry.tag))),
-                    self.dump_ifd_value(entry.get_ref(&path.chain_tag(entry.tag)))
+                    self.dump_tag_if_needed(entry.build_ref(&path.chain_tag(entry.tag))),
+                    self.dump_ifd_value(entry.build_ref(&path.chain_tag(entry.tag)))
                 )
             })
             .collect()
     }
     pub fn dump_ifd_value(&self, entry: IfdEntryRef) -> String {
-        if entry.tag.get_type_interpretation().is_some() {
+        if entry.tag.type_interpretation().is_some() {
             self.dump_ifd_value_with_type_interpretation(entry)
         } else {
             self.dump_ifd_value_plain(entry)
@@ -37,7 +37,7 @@ impl IfdYamlDumper {
             return s;
         }
 
-        match entry.tag.get_type_interpretation().unwrap() {
+        match entry.tag.type_interpretation().unwrap() {
             IfdTypeInterpretation::Enumerated { values } => {
                 if let Some(num) = entry.value.as_u32() {
                     if let Some((_, v)) = values.iter().find(|(k, _)| *k == num) {
@@ -65,11 +65,11 @@ impl IfdYamlDumper {
                     format!("{x}/{y}")
                 }
             }
-            IfdValue::SByte(x) => format!("{x}"),
+            IfdValue::SignedByte(x) => format!("{x}"),
             IfdValue::Undefined(x) => format!("{x:#02X}"),
-            IfdValue::SShort(x) => format!("{x}"),
-            IfdValue::SLong(x) => format!("{x}"),
-            IfdValue::SRational(x, y) => {
+            IfdValue::SignedShort(x) => format!("{x}"),
+            IfdValue::SignedLong(x) => format!("{x}"),
+            IfdValue::SignedRational(x, y) => {
                 if self.dump_rational_as_float {
                     format!("{}", *x as f32 / *y as f32)
                 } else {
@@ -120,14 +120,14 @@ impl IfdYamlDumper {
         }
     }
     fn dump_tag_if_needed(&self, entry: IfdEntryRef) -> String {
-        if let Some(types) = entry.tag.get_known_value_type() {
-            if types.contains(&entry.value.get_ifd_value_type()) {
+        if let Some(types) = entry.tag.known_value_type() {
+            if types.contains(&entry.value.ifd_value_type()) {
                 return "".to_string();
             }
         }
         format!(
             "!{} ",
-            Self::dump_ifd_value_type(&entry.value.get_ifd_value_type())
+            Self::dump_ifd_value_type(&entry.value.ifd_value_type())
         )
     }
     fn dump_ifd_value_type(v: &IfdValueType) -> &str {
@@ -137,11 +137,11 @@ impl IfdYamlDumper {
             IfdValueType::Short => "SHORT",
             IfdValueType::Long => "LONG",
             IfdValueType::Rational => "RATIONAL",
-            IfdValueType::SByte => "SBYTE",
+            IfdValueType::SignedByte => "SBYTE",
             IfdValueType::Undefined => "UNDEFINED",
-            IfdValueType::SShort => "SSHORT",
-            IfdValueType::SLong => "SLONG",
-            IfdValueType::SRational => "SRATIONAL",
+            IfdValueType::SignedShort => "SSHORT",
+            IfdValueType::SignedLong => "SLONG",
+            IfdValueType::SignedRational => "SRATIONAL",
             IfdValueType::Float => "FLOAT",
             IfdValueType::Double => "DOUBLE",
         }


### PR DESCRIPTION
* Make naming adhere to [Rust API guidelines](https://rust-lang.github.io/api-guidelines/naming.html).
   * `get_` prefixes were removed where neccessary.
   * Some functions were renamed to reflect common practices found in modern crates.
   * Some traits were implemented to replace certain getters resp. allow more canonical use of the API. E.g. `AsRef`, `TryFrom` or `From`.
   * Some enum variants were renamed. I.e. `SByte` etc. became `SignedByte` etc. since the above API guidelines call for `Sbyte` otherwise, which is less easy on the eyes.
   
* Docs had newlines & missing periods added where necessary and spaces removed. The latter particularly [before/after a slash '/'](https://english.stackexchange.com/questions/2131/should-i-write-module-theme-or-module-theme)).
  * On that note, I'm about to open a feature suggestion for `rustdoc` to add a _hair space_ (`U+200A`) automatically before/after a slash.
     
     That has the nice side-effect that the browser will (line) break at the slash without having to add the eyesore that a full space before/after introduces. This is only relevant for long words separated by a slash anyway; i.e. not this crate.
     
     See e.g. the [Wikipedia section about em/en-dashes](https://en.wikipedia.org/wiki/Whitespace_character#Hair_spaces_around_dashes) for the same (introducing line breaks w/o adding visible spacing).
  
* Updated/fixed some CLI help/about messages.

* Bumped dependencies in `Cargo.toml` (& removed patch version) and bumped crate version to `1.6.0` to signal API breakage introduced by this PR.